### PR TITLE
chore: use shared workflows from stonyx-workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,35 +2,15 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - dev
-      - main
+    branches: [dev, main]
 
 concurrency:
   group: ci-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 24.13.0
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Run tests
-        run: pnpm test
+    uses: abofs/stonyx-workflows/.github/workflows/ci.yml@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,6 @@
 name: Publish to NPM
 
 on:
-  # Manual trigger (kept for flexibility)
   workflow_dispatch:
     inputs:
       version-type:
@@ -9,7 +8,6 @@ on:
         required: true
         type: choice
         options:
-          - alpha
           - patch
           - minor
           - major
@@ -17,127 +15,21 @@ on:
         description: 'Custom version (optional, overrides version-type)'
         required: false
         type: string
-
-  # Auto-publish alpha on PR
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [main, dev]
-
-  # Auto-publish stable on merge to main
   push:
     branches: [main]
 
 permissions:
   contents: write
-  id-token: write  # Required for npm provenance
-  pull-requests: write  # For PR comments
+  id-token: write
+  pull-requests: write
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          # For PR events, check out the PR branch
-          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 24.13.0
-          cache: 'pnpm'
-          registry-url: 'https://registry.npmjs.org'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Run tests
-        run: pnpm test
-
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      # Determine version type based on trigger
-      - name: Determine version bump type
-        id: version-type
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "type=alpha" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event_name }}" = "push" ]; then
-            echo "type=patch" >> $GITHUB_OUTPUT
-          elif [ "${{ github.event.inputs.custom-version }}" != "" ]; then
-            echo "type=custom" >> $GITHUB_OUTPUT
-          else
-            echo "type=${{ github.event.inputs.version-type }}" >> $GITHUB_OUTPUT
-          fi
-
-      # Version bumping
-      - name: Bump version (custom)
-        if: steps.version-type.outputs.type == 'custom'
-        run: pnpm version ${{ github.event.inputs.custom-version }} --no-git-tag-version
-
-      - name: Bump version (alpha)
-        if: steps.version-type.outputs.type == 'alpha'
-        run: pnpm version prerelease --preid=alpha --no-git-tag-version
-
-      - name: Bump version (patch/minor/major)
-        if: steps.version-type.outputs.type == 'patch' || steps.version-type.outputs.type == 'minor' || steps.version-type.outputs.type == 'major'
-        run: pnpm version ${{ steps.version-type.outputs.type }} --no-git-tag-version
-
-      - name: Get package version
-        id: package-version
-        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
-
-      # Publishing
-      - name: Publish to NPM (alpha)
-        if: contains(steps.package-version.outputs.version, 'alpha')
-        run: pnpm publish --tag alpha --access public --no-git-checks
-
-      - name: Publish to NPM (stable)
-        if: "!contains(steps.package-version.outputs.version, 'alpha')"
-        run: pnpm publish --access public
-
-      # Only commit and tag for stable releases (push to main or manual stable)
-      - name: Commit version bump and create tag
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !contains(steps.package-version.outputs.version, 'alpha'))
-        run: |
-          git add package.json
-          git commit -m "chore: release v${{ steps.package-version.outputs.version }}"
-          git tag v${{ steps.package-version.outputs.version }}
-          git push origin main --tags
-
-      - name: Create GitHub Release
-        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !contains(steps.package-version.outputs.version, 'alpha'))
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: v${{ steps.package-version.outputs.version }}
-          release_name: v${{ steps.package-version.outputs.version }}
-          draft: false
-          prerelease: false
-
-      # Add PR comment with alpha version info
-      - name: Comment on PR with alpha version
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const version = '${{ steps.package-version.outputs.version }}';
-            const packageName = require('./package.json').name;
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `## 🚀 Alpha Version Published\n\n**Version:** \`${version}\`\n\n**Install:**\n\`\`\`bash\npnpm add ${packageName}@${version}\n# or\npnpm add ${packageName}@alpha  # latest alpha\n\`\`\`\n\nThis alpha version is now available for testing!`
-            });
+    uses: abofs/stonyx-workflows/.github/workflows/npm-publish.yml@main
+    with:
+      version-type: ${{ github.event.inputs.version-type }}
+      custom-version: ${{ github.event.inputs.custom-version }}
+    secrets: inherit


### PR DESCRIPTION
## Summary

Migrates CI and publish workflows to use the centralized reusable workflows from [`abofs/stonyx-workflows`](https://github.com/abofs/stonyx-workflows).

**Before:** 181 lines of workflow logic duplicated in this repo
**After:** 51 lines (thin callers that delegate to shared workflows)

## Changes

- Both workflows now have explicit `permissions` blocks at the workflow level (not job level) to satisfy CodeQL
- Alpha/beta/stable release stages are now handled by the shared workflow

## Test plan

- [ ] PR triggers CI → tests run via shared `ci.yml`
- [ ] PR triggers publish → alpha publishes via shared `npm-publish.yml`
- [ ] Verify no CodeQL warnings about missing permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)