### PR TITLE
feat: add cascade publish support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 name: Publish to NPM
 
 on:
+  repository_dispatch:
+    types: [cascade-publish]
   workflow_dispatch:
     inputs:
       version-type:
@@ -21,6 +23,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.event_name == 'repository_dispatch' && 'cascade-update' || format('publish-{0}', github.ref) }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   id-token: write
@@ -28,8 +34,18 @@ permissions:
 
 jobs:
   publish:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     uses: abofs/stonyx-workflows/.github/workflows/npm-publish.yml@main
     with:
       version-type: ${{ github.event.inputs.version-type }}
       custom-version: ${{ github.event.inputs.custom-version }}
+      cascade-source: ${{ github.event.client_payload.source_package || '' }}
+    secrets: inherit
+
+  cascade:
+    needs: publish
+    uses: abofs/stonyx-workflows/.github/workflows/cascade.yml@main
+    with:
+      package-name: ${{ needs.publish.outputs.package-name }}
+      published-version: ${{ needs.publish.outputs.published-version }}
     secrets: inherit

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "node-chronicle": "^0.2.0"
   },
   "devDependencies": {
-    "@stonyx/utils": "file:../stonyx-utils",
+    "@stonyx/utils": "0.2.3-beta.2",
     "qunit": "^2.24.1",
     "sinon": "^21.0.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
         version: 0.2.0
     devDependencies:
       '@stonyx/utils':
-        specifier: file:../stonyx-utils
-        version: file:../stonyx-utils
+        specifier: 0.2.3-beta.2
+        version: 0.2.3-beta.2
       qunit:
         specifier: ^2.24.1
         version: 2.25.0
@@ -33,8 +33,8 @@ packages:
   '@sinonjs/samsam@8.0.3':
     resolution: {integrity: sha512-hw6HbX+GyVZzmaYNh82Ecj1vdGZrqVIn/keDTg63IgAwiQPO+xCz99uG6Woqgb4tM0mUiFENKZ4cqd7IX94AXQ==}
 
-  '@stonyx/utils@file:../stonyx-utils':
-    resolution: {directory: ../stonyx-utils, type: directory}
+  '@stonyx/utils@0.2.3-beta.2':
+    resolution: {integrity: sha512-GsKNqYPtf2SpvcDTvWB+TBee7uzDeLWXjXDHwSQR/Y6wTMbjH6YtU4gaITB19P74vGe/4Xwpuf+3UTeM0/3PjQ==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -201,7 +201,7 @@ snapshots:
       '@sinonjs/commons': 3.0.1
       type-detect: 4.1.0
 
-  '@stonyx/utils@file:../stonyx-utils': {}
+  '@stonyx/utils@0.2.3-beta.2': {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:


### PR DESCRIPTION
## Summary
- Add `repository_dispatch` trigger and cascade job to `publish.yml` for automated downstream dependency updates
- Replace `file:../` references in `package.json` with real npm versions (latest beta pins)
- Regenerate `pnpm-lock.yaml` with npm registry versions

## Test plan
- [ ] `pnpm install` succeeds with npm versions
- [ ] CI tests pass on the PR
- [ ] Workflow YAML is valid (no syntax errors in Actions tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)