### PR TITLE
fix: skip postinstall for global installations

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,4 +1,8 @@
-import { copyFile, createDirectory } from '@stonyx/utils/file';
+// Skip postinstall for global installations
+const isGlobal = !process.env.INIT_CWD || process.env.npm_config_global === 'true';
+if (isGlobal) process.exit(0);
+
+const { copyFile, createDirectory } = await import('@stonyx/utils/file');
 
 const projectDir = process.env.INIT_CWD;
 const configDir = `${projectDir}/config`;


### PR DESCRIPTION
## Summary
- Global `npm i -g stonyx` fails because the postinstall script imports `@stonyx/utils/file`, which is a devDependency and unavailable during global install
- Adds an early exit guard for global installs (`npm_config_global` / missing `INIT_CWD`)
- Converts the static import to a dynamic `await import()` so module resolution is deferred until after the guard

## Test plan
- [x] `npm i -g .` succeeds (postinstall skips cleanly)
- [x] Consumer install with existing `environment.js` — runs without error, skips copy
- [x] Consumer install without `environment.js` — creates file and prints success message