### PR TITLE
chore: remove dual lockfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ config/environment.js
 
 # npm auth (never commit tokens)
 .npmrc
+package-lock.json


### PR DESCRIPTION
Removes package-lock.json — pnpm is the standard package manager for all Stonyx repos. Having both lockfiles risks inconsistent dependency resolution between CI and local development.