### PR TITLE
refactor: replace node-chronicle with @stonyx/logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@stonyx/utils": "0.2.3-beta.7",
-    "node-chronicle": "^0.2.0"
+    "@stonyx/logs": "^1.0.0"
   },
   "devDependencies": {
     "qunit": "^2.24.1",

--- a/src/main.js
+++ b/src/main.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import Chronicle from 'node-chronicle';
+import Chronicle from '@stonyx/logs';
 import loadModules from './modules.js';
 import { kebabCaseToCamelCase } from '@stonyx/utils/string';
 import { mergeObject } from '@stonyx/utils/object';


### PR DESCRIPTION
## Summary
- Updates dependency from `node-chronicle` to `@stonyx/logs` in package.json
- Updates import in `src/main.js` from `node-chronicle` to `@stonyx/logs`

## Context
stonyx-logs is the new scoped package name for the logging library, replacing the legacy `node-chronicle` name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)