### PR TITLE
fix: add explicit files whitelist for npm publish safety

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,10 @@
-# tests
-test/
-
-# config
-.nvmrc
-
-# git
 .git
+.env
+.npmrc
+.claude/
+.github/
+test/
+scripts/
+*.log
+.nvmrc
+.gitignore

--- a/package.json
+++ b/package.json
@@ -25,6 +25,11 @@
     "type": "git",
     "url": "git+https://github.com/abofs/stonyx.git"
   },
+  "files": [
+    "src",
+    "config",
+    "README.md"
+  ],
   "publishConfig": {
     "provenance": true
   },


### PR DESCRIPTION
## Summary
- Add explicit `files` whitelist (`src`, `config`, `README.md`) to `package.json` to control exactly what gets published to npm
- Replace minimal `.npmignore` with comprehensive exclusions (`.env`, `.npmrc`, `.claude/`, `.github/`, `test/`, `scripts/`, `*.log`, etc.)
- Verified with `npm pack --dry-run` that only intended files are included

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)