### PR TITLE
docs: fix orphaned context links and reduce duplication

### DIFF
--- a/docs/conventions/framework-modules.md
+++ b/docs/conventions/framework-modules.md
@@ -4,7 +4,7 @@ When to use which `@stonyx/*` module. Always check these before reaching for Nod
 
 ## `stonyx/log`
 
-All logging goes through `stonyx/log`. Never use `console.log`, `console.warn`, or `console.error`.
+All logging goes through `stonyx/log` (see universal rules in [conventions index](./index.md)).
 
 ```js
 import log from 'stonyx/log';
@@ -26,8 +26,6 @@ export default {
 Utility library organized by domain. Always check here before using Node built-ins or adding npm dependencies.
 
 ### File I/O (`@stonyx/utils/file`)
-
-**`fs` is explicitly prohibited.** Use these instead:
 
 - `createFile(filePath, data, options?)` — write a new file (creates parent dirs)
 - `updateFile(filePath, data, options?)` — atomic update via swap file

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,11 @@
 - [Testing](testing.md) — Running tests, config overrides, and integration helpers
 - [Developing Modules](developing-modules.md) — Guide for building custom Stonyx modules
 
+## Conventions
+
+- [Conventions](conventions/index.md) — Universal rules and module-specific conventions
+
 ## Reference
 
 - [API Reference](api.md) — Public exports and class documentation
+- [Release](release.md) — Release process


### PR DESCRIPTION
## Summary

- Link `conventions/index.md` and `release.md` from `docs/index.md` so agents following the context chain from `.claude/CLAUDE.md` can discover the full docs tree (conventions were previously orphaned)
- Remove restated universal rules from `docs/conventions/framework-modules.md` (console.log prohibition, fs prohibition) that are already defined in the conventions index, replacing with a back-reference

## Context

Full context review of `.claude/` directory and all referenced docs. Findings:

- **Entry point (`.claude/CLAUDE.md`)**: Properly thin -- one-liner description, link to `docs/index.md`, and agent-specific config. No issues.
- **Orphaned files**: `docs/conventions/index.md` (7 convention files with 8 sub-files) and `docs/release.md` were unreachable from `docs/index.md`. Fixed.
- **Directive duplication**: `framework-modules.md` restated 2 universal rules already in `conventions/index.md`. Tightened.
- **No contradictions** found across any files.
- **No stale references** found.
- **Verification coverage** is solid (test commands documented in 4 places with consistent info).

## Test plan

- [ ] Verify all markdown links in `docs/index.md` resolve correctly
- [ ] Verify the back-reference link in `docs/conventions/framework-modules.md` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)