### PR TITLE
fix: include app module in SIGTERM shutdown lifecycle

### DIFF
--- a/src/cli/serve.js
+++ b/src/cli/serve.js
@@ -32,7 +32,18 @@ export default async function serve({ args }) {
 
   const entryModule = await import(`${cwd}/${entryPoint}`);
 
+  let appInstance;
   if (entryModule.default) {
-    new entryModule.default();
+    appInstance = new entryModule.default();
+  }
+
+  // Include the app instance in shutdown if it has a shutdown method
+  if (appInstance && typeof appInstance.shutdown === 'function') {
+    const originalShutdown = shutdown;
+    const appShutdown = createShutdownHandler([...modules, appInstance]);
+    process.removeListener('SIGTERM', originalShutdown);
+    process.removeListener('SIGINT', originalShutdown);
+    process.on('SIGTERM', appShutdown);
+    process.on('SIGINT', appShutdown);
   }
 }


### PR DESCRIPTION
## Summary
- Entry module (app.js) was created after SIGTERM handlers were registered
- Its `shutdown()` method was never called during graceful shutdown
- Now re-registers SIGTERM/SIGINT handlers to include the app instance if it exposes `shutdown()`
- Enables downstream apps (like Trix) to clean up resources during process termination

## Test plan
- [x] Code review of serve.js lifecycle changes
- [ ] `trix restart` should trigger app's `shutdown()` method
- [ ] Stonyx framework modules still get their shutdown hooks called

🤖 Generated with [Claude Code](https://claude.com/claude-code)