### PR TITLE
fix: replace double casts and non-null assertions with runtime validation

### DIFF
--- a/src/cli/load-commands.ts
+++ b/src/cli/load-commands.ts
@@ -44,6 +44,7 @@ export default async function loadModuleCommands(): Promise<Record<string, Comma
 
     try {
       const commandsModule = await import(path.join(cwd, 'node_modules', moduleName, moduleExports['./commands']));
+      if (!commandsModule.default || typeof commandsModule.default !== 'object') continue;
       const moduleCommands = commandsModule.default as Record<string, CommandDefinition>;
 
       for (const [name, command] of Object.entries(moduleCommands)) {

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -14,7 +14,7 @@ export function createShutdownHandler(modules: StoynxModule[]): () => Promise<vo
 export default async function serve({ args }: { args: string[] }): Promise<void> {
   const cwd = process.cwd();
   const entryFlag = args.indexOf('--entry');
-  const entryPoint = entryFlag !== -1 ? args[entryFlag + 1] : 'app.js';
+  const entryPoint = (entryFlag !== -1 && entryFlag + 1 < args.length) ? args[entryFlag + 1] : 'app.js';
 
   const { default: config } = await import(`${cwd}/config/environment.js`);
   const { default: Stonyx } = await import('../main.js');

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,7 +44,8 @@ export default class Stonyx {
 
     // Transform config from stonyx-modules running as a standalone
     if (rootPath.includes('stonyx-')) {
-      const moduleName = kebabCaseToCamelCase(rootPath.split('/').pop()!.replace('stonyx-', ''));
+      const dirName = rootPath.split('/').pop() ?? '';
+      const moduleName = kebabCaseToCamelCase(dirName.replace('stonyx-', ''));
       config = { [moduleName]: config, ...((config as Record<string, unknown>).modules as Record<string, unknown> || {}) };
       delete (config as Record<string, unknown>).modules;
     }
@@ -76,7 +77,7 @@ export default class Stonyx {
 
     for (const [ className, config ] of Object.entries(this.config)) {
       if (!config || typeof config !== 'object') continue;
-      if ((chronicle as unknown as Record<string, unknown>)[className]) continue;
+      if (className in chronicle) continue;
 
       const { logColor, logMethod, logTimestamp } = config as Record<string, unknown>;
 

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -50,9 +50,9 @@ export default async function loadModules(
 ): Promise<StoynxModule[]> {
   const modules: StoynxModule[] = [];
   const initPromises: Promise<void>[] = [];
-  const rootPackage = await readFile(`${rootPath}/package.json`, { json: true }) as Record<string, Record<string, unknown> & string>;
-  const dependencies = rootPackage.devDependencies as Record<string, string>;
-  const projectName = rootPackage.name as unknown as string;
+  const rootPackage = await readFile(`${rootPath}/package.json`, { json: true }) as Record<string, unknown>;
+  const dependencies = (rootPackage.devDependencies || {}) as Record<string, string>;
+  const projectName = typeof rootPackage.name === 'string' ? rootPackage.name : '';
 
   // Expose rootPath to public configuration
   config.rootPath = rootPath;
@@ -69,12 +69,12 @@ export default async function loadModules(
   }
 
   // Standalone module configuration
-  if ((rootPackage.keywords as unknown as string[])?.includes('stonyx-module')) {
+  if (Array.isArray(rootPackage.keywords) && rootPackage.keywords.includes('stonyx-module')) {
     configureLog(chronicle, projectName, config as Record<string, unknown>);
 
-    const entryPoint = rootPackage.main as unknown as string;
+    const entryPoint = typeof rootPackage.main === 'string' ? rootPackage.main : '';
     const { default: moduleClass } = await import(`${rootPath}/${entryPoint}`);
-    initializeModule(rootPackage.name as unknown as string, moduleClass, modules, initPromises);
+    initializeModule(projectName, moduleClass, modules, initPromises);
   }
 
   for (const moduleName of moduleDependencies) {
@@ -85,7 +85,7 @@ export default async function loadModules(
 
     if (!modulePackage) continue;
 
-    const keywords = modulePackage.keywords as string[];
+    const keywords = Array.isArray(modulePackage.keywords) ? modulePackage.keywords as string[] : [];
 
     if (!keywords.includes('stonyx-module')) {
       console.warn(`Warning: Stonyx modules must contain the "stonyx-module" keyword. Module was not loaded`);
@@ -101,7 +101,7 @@ export default async function loadModules(
       // Load & Configure Async Modules
       const { default: moduleConfig } = await import(`${rootPath}/node_modules/${moduleName}/config/environment.js`);
 
-      const module = kebabCaseToCamelCase(moduleName.split('/').pop()!);
+      const module = kebabCaseToCamelCase(moduleName.split('/').pop() ?? moduleName);
       const userConfig = (config[module] as Record<string, unknown>) || {};
       const finalConfig = mergeObject(moduleConfig, userConfig);
       config[module] = finalConfig;


### PR DESCRIPTION
## Summary
- Replace 5× `as unknown as T` double casts with `typeof` / `Array.isArray` runtime checks in modules.ts
- Replace 2× `.pop()!` non-null assertions with `?? fallback` in modules.ts and main.ts
- Add bounds check for `--entry` flag index access in cli/serve.ts
- Add `typeof` validation before casting dynamic import default in cli/load-commands.ts

Closes #40

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `pnpm test` — 41/41 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)