### PR TITLE
docs: add project-level SME agent templates

### DIFF
--- a/docs/agents/architect.md
+++ b/docs/agents/architect.md
@@ -1,0 +1,41 @@
+# SME Template: Architect — Stonyx
+
+> **Inherits from:** `beatrix-shared/docs/framework/templates/agents/architect.md`
+> Load the base template first, then layer this project-specific context on top.
+
+## Project Context
+
+**Repo:** `abofs/stonyx`
+**Framework:** Core application framework for modular Node.js projects
+**Domain:** Provides the foundational runtime — module loader, configuration system, lifecycle hooks, CLI tooling, and centralized logging — that all `@stonyx/*` modules depend on
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Language | TypeScript (compiled to ES Modules) |
+| Runtime | Node.js |
+| Logging | `@stonyx/logs` (Chronicle — color-coded, extensible) |
+| Utilities | `@stonyx/utils` (string, file, object helpers) |
+| Testing | QUnit + Sinon |
+| Build | `tsc` (two configs: `tsconfig.json` for dist, `tsconfig.test.json` for dist-test) |
+| Package Manager | pnpm |
+| CI | GitHub Actions |
+
+## Architecture Patterns
+
+- **Singleton framework instance:** `Stonyx` class enforces a single instance via constructor guard; exposes static `log`, `config`, and `ready` accessors
+- **Async module loader:** Scans `devDependencies` for `@stonyx/*` packages, filters by `stonyx-module` / `stonyx-async` keywords, imports each module's `config/environment.js` defaults, merges with user config, then calls `init()` concurrently
+- **Deferred module readiness:** Each module gets a `DeferredPromise`; `waitForModule(name)` lets dependent modules block until their prerequisite finishes initializing (e.g., ORM waiting for rest-server)
+- **Lifecycle hooks:** Modules implement `init()`, `startup()`, and `shutdown()` from the `StoynxModule` interface; shutdown runs in reverse registration order with error isolation
+- **Config merge strategy:** Module defaults from `config/environment.js` are deep-merged with user overrides using `mergeObject`; test environment auto-merges from `test/config/environment.js` when `NODE_ENV=test`
+- **CLI as entry point:** `stonyx serve` bootstraps the full framework; `stonyx test` sets up test environment; `stonyx new` scaffolds projects with interactive module selection
+- **User-defined logging:** Any config key with a `logColor` property automatically gets a named Chronicle log method at startup
+
+## Live Knowledge
+
+- The module loader uses `kebabCaseToCamelCase` to convert package names (e.g., `@stonyx/rest-server` becomes `restServer` config key) — config key mismatches are a common integration issue
+- Standalone module mode (when `rootPath` contains `stonyx-`) transforms config structure differently to support running modules in isolation during development
+- `Stonyx.modulePromises` is populated before any module `init()` runs, so `waitForModule` is safe to call from any module's `init()` without race conditions
+- The `postinstall` script handles first-time setup; `prepublishOnly` runs the full test suite before npm publish
+- Exports are split across subpaths: `stonyx/config`, `stonyx/log`, `stonyx/test-helpers`, `stonyx/lifecycle` — consumer code imports these directly, not from the main entry

--- a/docs/agents/qa-test-engineer.md
+++ b/docs/agents/qa-test-engineer.md
@@ -1,0 +1,34 @@
+# SME Template: QA Test Engineer — Stonyx
+
+> **Inherits from:** `beatrix-shared/docs/framework/templates/agents/qa-test-engineer.md`
+> Load the base template first, then layer this project-specific context on top.
+
+## Project Context
+
+**Repo:** `abofs/stonyx`
+**Framework:** Core application framework for modular Node.js projects
+**Domain:** Runtime module loading, configuration merging, lifecycle management, and CLI tooling
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Test Runner | QUnit |
+| Mocking | Sinon |
+| Build (tests) | `tsc -p tsconfig.test.json` (outputs to `dist-test/`) |
+| Test Command | `pnpm build && pnpm build:test && qunit 'dist-test/test/**/*-test.js'` |
+
+## Architecture Patterns
+
+- **Two-stage build for tests:** Source compiles to `dist/`, tests compile separately to `dist-test/` with their own `tsconfig.test.json` — tests import from `dist/` so both builds must succeed
+- **Unit tests only:** Tests live under `test/unit/` — no integration test directory exists; framework is tested in isolation from downstream modules
+- **Config override mechanism:** Test environment automatically merges `test/config/environment.js` when `NODE_ENV=test`, enabling per-test config without modifying source
+- **Singleton reset required:** The `Stonyx` singleton persists across tests; teardown must reset `Stonyx.instance`, `Stonyx.initialized`, and `Stonyx.modulePromises` to avoid test pollution
+
+## Live Knowledge
+
+- Tests run via the `stonyx test` CLI command in downstream projects, but this repo uses `qunit` directly since it IS the framework
+- The `dist-test/` directory mirrors the `test/` structure; import paths in test files must account for the relative path from `dist-test/test/` to `dist/`
+- Module loading tests need to mock `@stonyx/utils/file` (specifically `readFile` for package.json parsing and `forEachFileImport` for module discovery) since real module resolution depends on `node_modules` layout
+- Chronicle (logging) tests should verify that `logColor` / `logMethod` / `logTimestamp` config keys produce the correct `defineType` calls — these are the user-facing log configuration hooks
+- The `waitForModule` function is a critical test target: verify it resolves when the module initializes, throws for unregistered modules, and handles concurrent callers correctly

--- a/docs/agents/validation-loop-team.md
+++ b/docs/agents/validation-loop-team.md
@@ -1,0 +1,35 @@
+# SME Template: Validation Loop Team — Stonyx
+
+> **Inherits from:** `beatrix-shared/docs/framework/templates/agents/validation-loop-team.md`
+> Load the base template first, then layer this project-specific context on top.
+
+## Project Context
+
+**Repo:** `abofs/stonyx`
+**Framework:** Core application framework for modular Node.js projects
+**Domain:** Module loading, configuration, lifecycle hooks, CLI — the foundation that all Stonyx modules and applications build on
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Language | TypeScript (ES Modules) |
+| Runtime | Node.js |
+| Testing | QUnit + Sinon |
+| Build | `tsc` with dual configs (src and test) |
+| CI | GitHub Actions (`ci.yml`) |
+
+## Architecture Patterns
+
+- **Singleton with static accessors:** `Stonyx.log`, `Stonyx.config` throw if accessed before initialization — guards prevent silent null-reference bugs in consumer code
+- **Concurrent module init with dependency ordering:** Modules initialize in parallel via `Promise.all`, but can declare sequential dependencies through `waitForModule()` — validation must cover both concurrent and sequential initialization paths
+- **Deep config merge:** `mergeObject` recursively merges module defaults with user overrides — edge cases include nested objects, arrays, and `undefined` vs missing keys
+- **Reverse-order shutdown:** Modules shut down in reverse registration order with `try/catch` isolation per module — a failing shutdown must not prevent subsequent modules from cleaning up
+
+## Live Knowledge
+
+- Breaking changes to the module loader interface (`StoynxModule`) cascade to every `@stonyx/*` package — any change to `init()`, `startup()`, or `shutdown()` signatures requires cross-repo validation
+- The `stonyx-module` and `stonyx-async` keyword detection in `package.json` is the gate for module loading — a missing keyword silently skips the module, which is an intentional design choice but a common debugging pitfall
+- Config key naming follows a strict convention: `@stonyx/rest-server` maps to `config.restServer` via `kebabCaseToCamelCase` — validate that any new module name converts correctly
+- The CLI (`stonyx new`, `stonyx serve`, `stonyx test`) is both a user-facing tool and the integration test surface — changes to CLI behavior affect every downstream project
+- Published package includes only `dist/`, `config/`, and `README.md` (per `files` in package.json) — verify that no source files or test artifacts leak into the npm package


### PR DESCRIPTION
## Summary
- Add `docs/agents/` directory with SME templates for architect, qa-test-engineer, and validation-loop-team roles
- Templates provide Stonyx-specific context overlays (module loader, config system, lifecycle hooks, CLI, Chronicle logging) that layer on top of beatrix-shared base templates
- Content derived from actual source analysis of `main.ts`, `modules.ts`, `lifecycle.ts`, and CLI structure

## Test plan
- [ ] Verify each template follows the exact format: title, inherits-from block, project context, tech stack table, architecture patterns, live knowledge
- [ ] Confirm architecture patterns and live knowledge sections reflect genuine project-specific details (not generic filler)
- [ ] Check that referenced file paths, class names, and config keys match the actual codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)