### PR TITLE
fix: include scripts/ directory in published tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "files": [
     "dist",
     "config",
+    "scripts",
     "README.md"
   ],
   "publishConfig": {


### PR DESCRIPTION
## Summary
- Adds `scripts` to the `files` glob in `package.json` so the `postinstall` lifecycle hook can find `scripts/postinstall.js` after `pnpm install` / `npm install`
- Fixes #47 — every published version since the TypeScript migration has been shipping a broken postinstall because the script file was excluded from the tarball
- Unblocks abofs/nextgoal-alerts#48 (Sprint 35 Wave 1 merge) and all other downstream consumers

## Root cause
`package.json` `files`: `["dist", "config", "README.md"]` — `scripts/` was never added, so the tarball did not include `scripts/postinstall.js` even though the `postinstall` script references it.

## Verification
Local `pnpm pack` now lists `scripts/postinstall.js` in the tarball contents:
```
dist/...
LICENSE.md
package.json
README.md
scripts/postinstall.js
```

Ground-truth verification will come from nextgoal-alerts PR #48 once the new beta publishes and the lockfile is bumped.

## Test plan
- [x] `pnpm pack` verifies `scripts/postinstall.js` in tarball
- [ ] After merge + publish, bump `stonyx` in nextgoal-alerts lockfile and confirm CI `pnpm install --frozen-lockfile` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)