### PR TITLE
fix: restore SIGTERM app.shutdown() invocation (#51)

### DIFF
--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -11,6 +11,26 @@ export function createShutdownHandler(modules: StoynxModule[]): () => Promise<vo
   };
 }
 
+export function maybeRegisterAppShutdown(
+  modules: StoynxModule[],
+  appInstance: unknown,
+  originalShutdown: () => Promise<void>
+): void {
+  if (
+    appInstance &&
+    typeof (appInstance as { shutdown?: unknown }).shutdown === 'function'
+  ) {
+    const appShutdown = createShutdownHandler([
+      ...modules,
+      appInstance as { shutdown?: () => Promise<void> }
+    ]);
+    process.removeListener('SIGTERM', originalShutdown);
+    process.removeListener('SIGINT', originalShutdown);
+    process.on('SIGTERM', appShutdown);
+    process.on('SIGINT', appShutdown);
+  }
+}
+
 export default async function serve({ args }: { args: string[] }): Promise<void> {
   const cwd = process.cwd();
   const entryFlag = args.indexOf('--entry');
@@ -32,7 +52,10 @@ export default async function serve({ args }: { args: string[] }): Promise<void>
 
   const entryModule = await import(`${cwd}/${entryPoint}`);
 
+  let appInstance: { shutdown?: () => Promise<void> } | undefined;
   if (entryModule.default) {
-    new entryModule.default();
+    appInstance = new entryModule.default();
   }
+
+  maybeRegisterAppShutdown(modules, appInstance, shutdown);
 }

--- a/test/unit/cli/serve-test.js
+++ b/test/unit/cli/serve-test.js
@@ -1,6 +1,6 @@
 import QUnit from 'qunit';
 import sinon from 'sinon';
-import serve, { createShutdownHandler } from '../../../src/cli/serve.js';
+import serve, { createShutdownHandler, maybeRegisterAppShutdown } from '../../../src/cli/serve.js';
 
 const { module, test } = QUnit;
 
@@ -56,6 +56,64 @@ module('[Unit] CLI Serve', function(hooks) {
 
       assert.ok(exitStub.calledOnce, 'process.exit called once');
       assert.ok(exitStub.calledWith(0), 'process.exit called with 0');
+    });
+  });
+
+  module('serve() handler registration', function(hooks) {
+    let onStub;
+    let removeListenerStub;
+    const originalShutdown = async () => {};
+
+    hooks.beforeEach(function() {
+      onStub = sinon.stub(process, 'on');
+      removeListenerStub = sinon.stub(process, 'removeListener');
+    });
+
+    test('re-registers handlers when entry module has shutdown()', function(assert) {
+      const modules = [];
+      const appInstance = { shutdown: async () => {} };
+
+      maybeRegisterAppShutdown(modules, appInstance, originalShutdown);
+
+      assert.ok(
+        removeListenerStub.calledWith('SIGTERM', originalShutdown),
+        'removed original SIGTERM listener'
+      );
+      assert.ok(
+        removeListenerStub.calledWith('SIGINT', originalShutdown),
+        'removed original SIGINT listener'
+      );
+      assert.equal(removeListenerStub.callCount, 2, 'removeListener called exactly twice');
+
+      const sigtermCalls = onStub.getCalls().filter(c => c.args[0] === 'SIGTERM');
+      const sigintCalls = onStub.getCalls().filter(c => c.args[0] === 'SIGINT');
+      assert.equal(sigtermCalls.length, 1, 'new SIGTERM handler registered');
+      assert.equal(sigintCalls.length, 1, 'new SIGINT handler registered');
+      assert.notStrictEqual(
+        sigtermCalls[0].args[1],
+        originalShutdown,
+        'new SIGTERM handler is not the original shutdown closure'
+      );
+    });
+
+    test('does NOT re-register when entry module lacks shutdown()', function(assert) {
+      const modules = [];
+      const appInstance = {};
+
+      maybeRegisterAppShutdown(modules, appInstance, originalShutdown);
+
+      assert.equal(removeListenerStub.callCount, 0, 'removeListener was not called');
+      assert.equal(onStub.callCount, 0, 'process.on was not called');
+    });
+
+    test('does NOT re-register when entry module has no default export', function(assert) {
+      const modules = [];
+      const appInstance = undefined;
+
+      maybeRegisterAppShutdown(modules, appInstance, originalShutdown);
+
+      assert.equal(removeListenerStub.callCount, 0, 'removeListener was not called');
+      assert.equal(onStub.callCount, 0, 'process.on was not called');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Ports PR #33 (main) into dev's TypeScript codebase — a regression live since beta.38 where the entry module's `shutdown()` was never invoked on SIGTERM/SIGINT
- `src/cli/serve.ts` lost the handler re-registration logic during the TypeScript migration; this restores it
- Extracts `maybeRegisterAppShutdown(modules, appInstance, originalShutdown)` helper so the three branches can be unit-tested without stubbing dynamic imports
- `appInstance` is typed structurally as `{ shutdown?: () => Promise<void> }` — not coupled to `StoynxModule`

Closes #51

## Test plan
- [x] `pnpm test` green (44/44, including 3 new regression tests)
- [x] Re-registers handlers when entry module has `shutdown()`
- [x] Does NOT re-register when entry module lacks `shutdown()`
- [x] Does NOT re-register when entry module has no default export
- [ ] Downstream `trix restart` should now trigger app's `shutdown()` after this lands and is consumed

🤖 Generated with [Claude Code](https://claude.com/claude-code)