### PR TITLE
fix: register QUnit.on('runEnd') to drain event loop after tests complete

### DIFF
--- a/src/cli/test-setup.ts
+++ b/src/cli/test-setup.ts
@@ -1,3 +1,4 @@
+import { createRequire } from 'module';
 import { pathToFileURL } from 'url';
 
 const cwd = process.cwd();
@@ -6,3 +7,28 @@ const { default: Stonyx } = await import('stonyx');
 const { default: config } = await import(pathToFileURL(`${cwd}/config/environment.js`).href);
 
 new Stonyx(config, cwd);
+
+// Drain the event loop once qunit finishes. Modules loaded by Stonyx
+// (e.g. @stonyx/rest-server) may keep listeners/servers open that would
+// otherwise block the process from exiting, causing CI to hit timeouts
+// even though all tests passed.
+//
+// qunit's CLI bin does `delete require.cache[qunitPath]` and re-requires
+// qunit before running, so any qunit instance we grab synchronously from
+// this --import setup is a DIFFERENT object than the one qunit's CLI
+// actually uses. We defer the hook registration with setImmediate so it
+// runs AFTER the qunit bin has populated require.cache with its own
+// instance; grabbing qunit via CJS require at that point returns the
+// instance the tests are running on.
+//
+// See: https://github.com/abofs/stonyx/issues/55
+const require = createRequire(import.meta.url);
+setImmediate(() => {
+  const qunitPath = require.resolve('qunit', {
+    paths: [`${cwd}/node_modules`, cwd]
+  });
+  const QUnit = require(qunitPath) as { on: (event: string, cb: () => void) => void };
+  QUnit.on('runEnd', () => {
+    setImmediate(() => process.exit(process.exitCode ?? 0));
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes the qunit event-loop hang that blocks `stonyx test` from exiting in projects with listener-keeping modules (e.g. `@stonyx/rest-server`) in devDependencies.
- Registers `QUnit.on('runEnd', ...)` in `src/cli/test-setup.ts` so the process force-exits after qunit flushes reporter output.
- Hook registration is deferred with `setImmediate` because qunit's CLI bin runs `delete require.cache[qunitPath]` and re-requires qunit; grabbing the instance synchronously from the `--import` setup gets a stale object. Deferring ensures we attach to the instance qunit's CLI actually runs on.

Closes #55

## Test plan

- [x] `pnpm build && pnpm test` in `stonyx/` — 44/44 pass, exits in ~1s
- [x] Local repro in `nextgoal-alerts` (has `@stonyx/rest-server` devDep): with `zz-exit-test.js` workaround removed and linked local stonyx, `pnpm test` exits immediately after qunit finishes instead of hanging 300s
- [ ] CI green on this PR
- [ ] Once merged to `dev`, confirm cascade-publish ships a new beta tag; verify by running `pnpm test` on `nextgoal-alerts` against the new beta with `zz-exit-test.js` removed