### PR TITLE
fix: skip postinstall env copy when consumer ships its own template (#54)

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -2,11 +2,16 @@
 const isGlobal = !process.env.INIT_CWD || process.env.npm_config_global === 'true';
 if (isGlobal) process.exit(0);
 
+const { existsSync } = await import('node:fs');
 const { copyFile, createDirectory } = await import('@stonyx/utils/file');
 
 const projectDir = process.env.INIT_CWD;
 const configDir = `${projectDir}/config`;
 const envFile = 'environment.js';
+
+// Skip if the consumer ships its own `config/environment copy.js` template —
+// they manage their own bootstrap (see abofs/stonyx#54).
+if (existsSync(`${configDir}/environment copy.js`)) process.exit(0);
 
 createDirectory(configDir);
 

--- a/test/unit/postinstall-test.ts
+++ b/test/unit/postinstall-test.ts
@@ -1,0 +1,48 @@
+import QUnit from 'qunit';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const { module, test } = QUnit;
+
+const postinstallScript = resolve(process.cwd(), 'scripts/postinstall.js');
+
+function runPostinstall(initCwd: string) {
+  // Run from the stonyx repo root so the script's relative `./config/environment copy.js`
+  // source resolves against the real stonyx template.
+  execFileSync('node', [postinstallScript], {
+    cwd: process.cwd(),
+    env: { ...process.env, INIT_CWD: initCwd, npm_config_global: 'false' },
+    stdio: 'pipe',
+  });
+}
+
+module('[Unit] Postinstall', function(hooks) {
+  let projectDir: string;
+
+  hooks.beforeEach(function() {
+    projectDir = mkdtempSync(join(tmpdir(), 'stonyx-postinstall-'));
+  });
+
+  hooks.afterEach(function() {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  test('copies environment.js when consumer has no template of its own', function(assert) {
+    runPostinstall(projectDir);
+    assert.ok(existsSync(join(projectDir, 'config/environment.js')), 'environment.js was created');
+  });
+
+  test('skips copy when consumer ships its own `config/environment copy.js` (abofs/stonyx#54)', function(assert) {
+    mkdirSync(join(projectDir, 'config'), { recursive: true });
+    writeFileSync(join(projectDir, 'config/environment copy.js'), '// consumer template\n');
+
+    runPostinstall(projectDir);
+
+    assert.notOk(
+      existsSync(join(projectDir, 'config/environment.js')),
+      'environment.js was not created when consumer ships its own template'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #54.

`scripts/postinstall.js` unconditionally copied stonyx's internal `config/environment copy.js` template into the consumer's `config/environment.js` during stonyx install. Consumer projects that ship their own (richer) `config/environment copy.js` and run their own postinstall to materialize it were being silently clobbered: stonyx's hook ran first and stubbed the file out, then the consumer's hook saw the file already existed and skipped. CI ended up running against the minimal stonyx stub.

## Fix

Per option 1 in the issue: guard the copy with a presence check for the consumer's own `config/environment copy.js`. If the consumer ships that file, they manage their own bootstrap — stonyx stays out of the way.

```js
if (existsSync(`${configDir}/environment copy.js`)) process.exit(0);
```

Global-install and missing-`INIT_CWD` behavior are unchanged.

## Test coverage

Added `test/unit/postinstall-test.ts` (new file — no prior postinstall suite existed). Two cases, each spawns the real `scripts/postinstall.js` with `INIT_CWD` pointed at a fresh temp dir:

1. No consumer template present -> `config/environment.js` is created (existing behavior).
2. Consumer template present -> `config/environment.js` is NOT created (regression guard for #54).

Full suite: `pnpm build && pnpm test` -> 46 pass, 0 fail.

## Test plan

- [x] `pnpm build` succeeds
- [x] `pnpm test` passes (46/46)
- [x] New postinstall tests exercise both the copy and skip paths