### PR TITLE
fix: support .ts config files across framework loader sites (#59)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,9 +4,9 @@ Stonyx uses a centralized configuration file that all modules read from at start
 
 ## Environment Config
 
-Your project's configuration lives at `config/environment.js`:
+Your project's configuration lives at `config/environment.ts` (preferred) or `config/environment.js`:
 
-```js
+```ts
 const { DEBUG, NODE_ENV } = process.env;
 
 const environment = NODE_ENV ?? 'development';
@@ -21,15 +21,17 @@ export default {
 };
 ```
 
-This file is auto-generated on `npm install` via the postinstall script if it doesn't already exist.
+Stonyx resolves the config by trying `.ts` first, then falling back to `.js`. If both are present `.ts` wins and a warning is logged — the `.js` is almost always a stale compiled artifact or postinstall stub and should be removed.
 
-> **Note:** `config/environment.js` is gitignored by default so each environment can have its own settings.
+The `.js` template is auto-generated on `npm install` via the postinstall script if neither extension exists yet.
+
+> **Note:** `config/environment.*` is gitignored by default so each environment can have its own settings.
 
 ## Module Configuration
 
 Each Stonyx module reads its configuration from a top-level key matching its camelCase name. For example, `@stonyx/rest-server` reads from `config.restServer`.
 
-Async modules ship with their own default config at `config/environment.js` inside the module package. Your project config is merged on top of these defaults — you only need to specify overrides.
+Async modules ship with their own default config at `config/environment.ts` (or `.js`) inside the module package. Your project config is merged on top of these defaults — you only need to specify overrides.
 
 ## Logging Configuration
 
@@ -49,10 +51,10 @@ This works for both module configs and custom service configs. See [Logging](log
 
 ## Test Environment Overrides
 
-When `NODE_ENV=test`, Stonyx automatically looks for `test/config/environment.js` in your project root:
+When `NODE_ENV=test`, Stonyx automatically looks for `test/config/environment.ts` (or `.js`) in your project root:
 
-```js
-// test/config/environment.js
+```ts
+// test/config/environment.ts
 export default {
   debug: false,
   restServer: { port: 0 },

--- a/docs/developing-modules.md
+++ b/docs/developing-modules.md
@@ -41,9 +41,9 @@ export default class MyModule {
 
 ## Default Configuration
 
-Async modules must include `config/environment.js` with sensible defaults:
+Async modules must include `config/environment.ts` (preferred) or `config/environment.js` with sensible defaults:
 
-```js
+```ts
 export default {
   logColor: 'cyan',
   logMethod: 'myModule',
@@ -51,6 +51,8 @@ export default {
   // Module-specific defaults...
 };
 ```
+
+Stonyx's loader tries `.ts` first, then falls back to `.js` for back-compat with modules that haven't migrated. If a module ships both, `.ts` wins and a warning is logged — the `.js` is almost certainly a stale compiled artifact and should be removed before publishing.
 
 User project config is merged on top of these defaults.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,9 @@ import test from './cli/test.js';
 import help from './cli/help.js';
 import newCommand from './cli/new.js';
 import loadModuleCommands from './cli/load-commands.js';
+import { importConfig } from './util/import-config.js';
 import type { CommandDefinition } from './cli/load-commands.js';
+import type { StoynxConfig } from './modules.js';
 
 try { process.loadEnvFile(); } catch { /* no .env file */ }
 
@@ -43,7 +45,7 @@ async function main(): Promise<void> {
     const cwd = process.cwd();
 
     if (moduleCommand.bootstrap) {
-      const { default: config } = await import(`${cwd}/config/environment.js`);
+      const config = await importConfig<StoynxConfig>(`${cwd}/config/environment`);
       const { default: Stonyx } = await import('./main.js');
       new Stonyx(config, cwd);
       await Stonyx.ready;

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -1,4 +1,6 @@
 import { runStartupHooks, runShutdownHooks, type StoynxModule } from '../lifecycle.js';
+import { importConfig } from '../util/import-config.js';
+import type { StoynxConfig } from '../modules.js';
 
 export function createShutdownHandler(modules: StoynxModule[]): () => Promise<void> {
   let shuttingDown = false;
@@ -36,7 +38,7 @@ export default async function serve({ args }: { args: string[] }): Promise<void>
   const entryFlag = args.indexOf('--entry');
   const entryPoint = (entryFlag !== -1 && entryFlag + 1 < args.length) ? args[entryFlag + 1] : 'app.js';
 
-  const { default: config } = await import(`${cwd}/config/environment.js`);
+  const config = await importConfig<StoynxConfig>(`${cwd}/config/environment`);
   const { default: Stonyx } = await import('../main.js');
 
   new Stonyx(config, cwd);

--- a/src/cli/test-setup.ts
+++ b/src/cli/test-setup.ts
@@ -1,10 +1,11 @@
 import { createRequire } from 'module';
-import { pathToFileURL } from 'url';
+import { importConfig } from '../util/import-config.js';
+import type { StoynxConfig } from '../modules.js';
 
 const cwd = process.cwd();
 
 const { default: Stonyx } = await import('stonyx');
-const { default: config } = await import(pathToFileURL(`${cwd}/config/environment.js`).href);
+const config = await importConfig<StoynxConfig>(`${cwd}/config/environment`);
 
 new Stonyx(config, cwd);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import Chronicle from '@stonyx/logs';
 import loadModules from './modules.js';
 import { kebabCaseToCamelCase } from '@stonyx/utils/string';
 import { mergeObject } from '@stonyx/utils/object';
+import { importConfig } from './util/import-config.js';
 import type { StoynxModule } from './lifecycle.js';
 import type { StoynxConfig } from './modules.js';
 
@@ -59,10 +60,13 @@ export default class Stonyx {
     // Uses in-place mutation to preserve existing references (e.g. stonyx/config export cache)
     if (process.env.NODE_ENV === 'test') {
       try {
-        const { default: testOverrides } = await import(`${rootPath}/test/config/environment.js`);
+        const testOverrides = await importConfig<Record<string, unknown>>(`${rootPath}/test/config/environment`);
         const merged = mergeObject(config as Record<string, unknown>, testOverrides);
         Object.assign(config, merged);
-      } catch { /* no test overrides found */ }
+      } catch (err) {
+        // Missing test override is non-fatal; re-throw import errors that aren't "not found"
+        if (!(err instanceof Error) || !err.message.startsWith('Config not found:')) throw err;
+      }
     }
 
     this.modules = await loadModules(config, rootPath, this.chronicle);

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -5,6 +5,7 @@
 import { readFile } from '@stonyx/utils/file';
 import { kebabCaseToCamelCase } from '@stonyx/utils/string';
 import { mergeObject } from '@stonyx/utils/object';
+import { importConfig } from './util/import-config.js';
 import type { StoynxModule } from './lifecycle.js';
 import type Chronicle from '@stonyx/logs';
 
@@ -99,7 +100,7 @@ export default async function loadModules(
 
     try {
       // Load & Configure Async Modules
-      const { default: moduleConfig } = await import(`${rootPath}/node_modules/${moduleName}/config/environment.js`);
+      const moduleConfig = await importConfig<Record<string, unknown>>(`${rootPath}/node_modules/${moduleName}/config/environment`);
 
       const module = kebabCaseToCamelCase(moduleName.split('/').pop() ?? moduleName);
       const userConfig = (config[module] as Record<string, unknown>) || {};
@@ -114,7 +115,7 @@ export default async function loadModules(
       initializeModule(moduleName, moduleClass, modules, initPromises);
     } catch (error) {
       console.error(error);
-      throw new Error(`Stonyx modules with async loading must have a config/environment.js file with default configurations. Module "${moduleName}" failed to load.`);
+      throw new Error(`Stonyx modules with async loading must have a config/environment.{ts,js} file with default configurations. Module "${moduleName}" failed to load.`);
     }
   }
 

--- a/src/util/import-config.ts
+++ b/src/util/import-config.ts
@@ -1,0 +1,22 @@
+import { existsSync } from 'fs';
+import { pathToFileURL } from 'url';
+
+const EXTENSIONS = ['ts', 'js'] as const;
+
+export async function importConfig<T = unknown>(basePath: string): Promise<T> {
+  const matches = EXTENSIONS.filter(ext => existsSync(`${basePath}.${ext}`));
+
+  if (matches.length === 0) {
+    throw new Error(`Config not found: ${basePath}.{ts,js}`);
+  }
+
+  if (matches.length > 1) {
+    console.warn(
+      `Warning: both ${basePath}.ts and ${basePath}.js exist. Using .ts — delete the .js to silence this warning (it is likely a stale compiled artifact or postinstall stub).`
+    );
+  }
+
+  const ext = matches[0];
+  const mod = await import(pathToFileURL(`${basePath}.${ext}`).href);
+  return mod.default as T;
+}

--- a/test/unit/import-config-test.ts
+++ b/test/unit/import-config-test.ts
@@ -1,0 +1,93 @@
+import QUnit from 'qunit';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { importConfig } from '../../src/util/import-config.js';
+
+const { module, test } = QUnit;
+
+let dir: string;
+let basePath: string;
+let originalWarn: typeof console.warn;
+let warnCalls: unknown[][];
+
+function setupWarnSpy(): void {
+  originalWarn = console.warn;
+  warnCalls = [];
+  console.warn = (...args: unknown[]) => { warnCalls.push(args); };
+}
+
+function restoreWarn(): void {
+  console.warn = originalWarn;
+}
+
+module('[Unit] importConfig', function(hooks) {
+  hooks.beforeEach(function() {
+    // Unique subdir per test so module import cache can't collide across tests
+    dir = mkdtempSync(join(tmpdir(), 'stonyx-import-config-'));
+    basePath = join(dir, 'environment');
+    setupWarnSpy();
+  });
+
+  hooks.afterEach(function() {
+    restoreWarn();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('returns default export when only .ts exists', async function(assert) {
+    writeFileSync(`${basePath}.ts`, `export default { source: 'ts', port: 3000 };\n`);
+
+    const config = await importConfig<{ source: string; port: number }>(basePath);
+
+    assert.equal(config.source, 'ts');
+    assert.equal(config.port, 3000);
+    assert.equal(warnCalls.length, 0, 'no warning logged');
+  });
+
+  test('returns default export when only .js exists', async function(assert) {
+    writeFileSync(`${basePath}.js`, `export default { source: 'js', port: 4000 };\n`);
+
+    const config = await importConfig<{ source: string; port: number }>(basePath);
+
+    assert.equal(config.source, 'js');
+    assert.equal(config.port, 4000);
+    assert.equal(warnCalls.length, 0, 'no warning logged');
+  });
+
+  test('prefers .ts when both exist and logs a warning', async function(assert) {
+    writeFileSync(`${basePath}.ts`, `export default { source: 'ts' };\n`);
+    writeFileSync(`${basePath}.js`, `export default { source: 'js' };\n`);
+
+    const config = await importConfig<{ source: string }>(basePath);
+
+    assert.equal(config.source, 'ts', '.ts wins');
+    assert.equal(warnCalls.length, 1, 'exactly one warning logged');
+    const [[msg]] = warnCalls as [[string]];
+    assert.ok(msg.includes('.ts'), 'warning mentions .ts');
+    assert.ok(msg.includes('.js'), 'warning mentions .js');
+  });
+
+  test('throws clear error when neither exists', async function(assert) {
+    try {
+      await importConfig(basePath);
+      assert.ok(false, 'should have thrown');
+    } catch (err) {
+      const message = (err as Error).message;
+      assert.ok(message.includes('Config not found'), 'error mentions "Config not found"');
+      assert.ok(message.includes('ts') && message.includes('js'), 'error references both extensions');
+    }
+  });
+
+  test('propagates non-"not found" import errors (syntax error)', async function(assert) {
+    writeFileSync(`${basePath}.ts`, `export default { this is invalid syntax !!! };\n`);
+
+    try {
+      await importConfig(basePath);
+      assert.ok(false, 'should have thrown');
+    } catch (err) {
+      const message = (err as Error).message;
+      assert.notOk(message.startsWith('Config not found'), 'not the "not found" error');
+      assert.ok(message.length > 0, 'has an error message');
+    }
+  });
+});


### PR DESCRIPTION
Closes #59.

## Summary

Five runtime `import()` sites in stonyx core hardcoded `config/environment.js` as the import target, causing silent failures for any consumer or module whose config has been TypeScript-migrated. This PR extracts a shared `importConfig` helper that tries `.ts` first, falls back to `.js` for back-compat, and logs a warning when both exist (the `.js` is almost always a stale compiled artifact or postinstall stub).

## Helper

New `src/util/import-config.ts`:

- uses `existsSync` to decide which extension wins (avoids catching `ERR_MODULE_NOT_FOUND`, which is fragile across Node versions)
- `.ts` wins when both are present; warns so migration issues surface
- throws a clear `Config not found: <basePath>.{ts,js}` error when neither exists
- propagates non-"not found" errors (e.g., syntax errors in the target file)

## Call sites updated

| File | Line (orig) | Change |
|---|---|---|
| `src/modules.ts` | 102 | module default config |
| `src/cli/serve.ts` | 39 | consumer config |
| `src/cli.ts` | 46 | consumer config for module commands |
| `src/cli/test-setup.ts` | 7 | consumer config under test (drops now-unused `pathToFileURL` import) |
| `src/main.ts` | 62 | optional test override; missing override stays non-fatal |

## Tests

New `test/unit/import-config-test.ts` covers:

- returns default export when only `.ts` exists
- returns default export when only `.js` exists
- prefers `.ts` when both exist (asserts warning logged)
- throws clear error when neither exists
- propagates non-"not found" import errors (syntax-error fixture)

## Docs

- `docs/configuration.md` §"Environment Config", §"Module Configuration", §"Test Environment Overrides" — note both `.ts` and `.js` are supported, `.ts` preferred
- `docs/developing-modules.md` §"Default Configuration" — same, with note that shipping both in a module signals a stale artifact

## Notes

Split from PR #63 (closed) after a shared-working-tree race during sprint-47 kickoff. Commit is the original `0a688b0` cherry-picked onto a clean base.

## Test plan

- [x] Full `pnpm test` was green (55/55) on the combined branch before the split
- [ ] CI green on this PR standalone