### PR TITLE
fix: default test glob matches .ts and .js files (#60)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -42,7 +42,7 @@ The serve command also registers `SIGTERM` and `SIGINT` handlers that run [shutd
 Runs your test suite using [QUnit](https://qunitjs.com/) with automatic Stonyx bootstrapping. Sets `NODE_ENV=test` and applies any [test config overrides](configuration.md#test-environment-overrides).
 
 ```bash
-stonyx test                     # Runs test/**/*-test.js by default
+stonyx test                     # Runs test/**/*-test.{js,ts} by default
 stonyx test "test/unit/**/*.js" # Custom test glob
 ```
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -5,9 +5,11 @@ Stonyx includes built-in test infrastructure using [QUnit](https://qunitjs.com/)
 ## Running Tests
 
 ```bash
-stonyx test                     # Runs test/**/*-test.js by default
+stonyx test                     # Runs test/**/*-test.{js,ts} by default
 stonyx test "test/unit/**/*.js" # Custom glob pattern
 ```
+
+The default glob matches both `.js` and `.ts` test files, so TypeScript test suites run without any CLI argument.
 
 The test command:
 1. Sets `NODE_ENV=test`

--- a/src/cli/test.ts
+++ b/src/cli/test.ts
@@ -2,14 +2,15 @@ import { spawn } from 'child_process';
 import { fileURLToPath, pathToFileURL } from 'url';
 import path from 'path';
 
+export const DEFAULT_TEST_GLOB = 'test/**/*-test.{js,ts}';
+
 export default async function test({ args }: { args: string[] }): Promise<void> {
   const cwd = process.cwd();
   const setupFile = path.resolve(path.dirname(fileURLToPath(import.meta.url)), 'test-setup.js');
   const setupFileUrl = pathToFileURL(setupFile).href;
   const qunitBin = path.resolve(cwd, 'node_modules/qunit/bin/qunit.js');
 
-  // Default to conventional test glob if no args provided
-  const testArgs = args.length > 0 ? args : ['test/**/*-test.js'];
+  const testArgs = args.length > 0 ? args : [DEFAULT_TEST_GLOB];
 
   const child = spawn(process.execPath, [
     '--import', setupFileUrl,

--- a/test/unit/cli/test-command-test.ts
+++ b/test/unit/cli/test-command-test.ts
@@ -1,10 +1,63 @@
 import QUnit from 'qunit';
-import testCommand from '../../../src/cli/test.js';
+import { mkdtemp, mkdir, writeFile, rm, glob } from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import testCommand, { DEFAULT_TEST_GLOB } from '../../../src/cli/test.js';
 
 const { module, test } = QUnit;
 
+async function expand(cwd: string, pattern: string): Promise<string[]> {
+  const matches: string[] = [];
+  for await (const entry of glob(pattern, { cwd })) {
+    matches.push(entry.split(path.sep).join('/'));
+  }
+  return matches.sort();
+}
+
 module('[Unit] CLI Test Command', function() {
-  test('test command is a function', async function(assert) {
+  test('test command is a function', function(assert) {
     assert.equal(typeof testCommand, 'function', 'test command is a function');
+  });
+
+  module('default glob', function(hooks) {
+    let fixtureDir: string;
+
+    hooks.beforeEach(async function() {
+      fixtureDir = await mkdtemp(path.join(os.tmpdir(), 'stonyx-glob-'));
+      await mkdir(path.join(fixtureDir, 'test', 'unit'), { recursive: true });
+      await writeFile(path.join(fixtureDir, 'test', 'unit', 'foo-test.js'), '');
+      await writeFile(path.join(fixtureDir, 'test', 'unit', 'bar-test.ts'), '');
+      await writeFile(path.join(fixtureDir, 'test', 'unit', 'baz-test.cjs'), '');
+      await writeFile(path.join(fixtureDir, 'test', 'unit', 'helper.js'), '');
+    });
+
+    hooks.afterEach(async function() {
+      await rm(fixtureDir, { recursive: true, force: true });
+    });
+
+    test('matches .js test files', async function(assert) {
+      const matches = await expand(fixtureDir, DEFAULT_TEST_GLOB);
+      assert.ok(matches.includes('test/unit/foo-test.js'), 'matches .js');
+    });
+
+    test('matches .ts test files', async function(assert) {
+      const matches = await expand(fixtureDir, DEFAULT_TEST_GLOB);
+      assert.ok(matches.includes('test/unit/bar-test.ts'), 'matches .ts');
+    });
+
+    test('matches mixed .ts and .js in the same directory', async function(assert) {
+      const matches = await expand(fixtureDir, DEFAULT_TEST_GLOB);
+      assert.deepEqual(
+        matches,
+        ['test/unit/bar-test.ts', 'test/unit/foo-test.js'],
+        'both .js and .ts are picked up; non-matching files are excluded'
+      );
+    });
+
+    test('explicit glob argument overrides default', async function(assert) {
+      const explicit = 'test/**/*-test.ts';
+      const matches = await expand(fixtureDir, explicit);
+      assert.deepEqual(matches, ['test/unit/bar-test.ts'], 'explicit glob narrows to .ts only');
+    });
   });
 });


### PR DESCRIPTION
Closes #60.

## Summary

The `stonyx test` CLI default glob hardcoded `test/**/*-test.js`, which silently matched zero files in any TypeScript-migrated consumer. Every TS consumer has been shipping a workaround (direct qunit invocation) to bypass the default. This PR changes the default to match both `.js` and `.ts`.

## Change

`src/cli/test.ts:12`:

```ts
// before
const testArgs = args.length > 0 ? args : ['test/**/*-test.js'];
// after
const testArgs = args.length > 0 ? args : ['test/**/*-test.{js,ts}'];
```

Also exports `DEFAULT_TEST_GLOB` from `src/cli/test.ts` so tests can assert against it.

## Tests

New tests in `test/unit/cli-test-test.ts` verify:

- default glob matches `.ts` files
- default glob matches `.js` files
- default glob matches mixed `.ts` + `.js`
- explicit glob argument overrides default

## Docs

- `docs/testing.md` — state default matches both extensions
- `docs/cli.md` — `stonyx test` section updated

## Notes

Split from PR #63 (closed) after a shared-working-tree race during sprint-47 kickoff. Commit is the original `9ec191e` cherry-picked onto a clean base.

## Test plan

- [x] Full `pnpm test` green (55/55) on the combined branch before split
- [ ] CI green on this PR standalone