### PR TITLE
fix: 'stonyx new' scaffolds .ts by default (#61)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,6 +26,53 @@ stonyx new              # Prompts for project name
 stonyx new my-app       # Creates my-app/ in the current directory
 ```
 
+Scaffolded projects are TypeScript-first: every consumer-authored source file is `.ts`, with a root `tsconfig.json`, and `tsx`/`typescript` in `devDependencies`.
+
+Generated layout (minimal — additional directories appear per the modules you select):
+
+```
+my-app/
+├── app.ts
+├── config/
+│   ├── environment.ts
+│   └── environment.example.ts
+├── test/
+│   ├── setup.ts           # Bootstraps Stonyx via await Stonyx.ready (Sprint 44 pattern)
+│   ├── zz-exit-test.ts    # runEnd hook that drains the event loop after tests
+│   ├── config/
+│   │   └── environment.ts
+│   ├── unit/
+│   ├── integration/
+│   └── acceptance/
+├── package.json
+├── tsconfig.json
+└── .gitignore
+```
+
+The scaffolded `package.json` uses the Sprint 44 test pattern:
+
+```json
+{
+  "scripts": {
+    "build": "tsc",
+    "serve": "stonyx serve",
+    "start": "stonyx serve",
+    "test": "NODE_ENV=test node --import tsx/esm --import ./test/setup.ts node_modules/qunit/bin/qunit.js 'test/**/*-test.ts'"
+  }
+}
+```
+
+`config/environment.ts` is scaffolded with a typed default export so new projects get type-checking out of the box:
+
+```ts
+import type { StoynxConfig } from 'stonyx';
+
+const config: StoynxConfig = {
+};
+
+export default config;
+```
+
 ### serve
 
 Bootstraps Stonyx (loads config, initializes modules, runs lifecycle hooks), then imports your application entry point.

--- a/src/cli/new.ts
+++ b/src/cli/new.ts
@@ -60,7 +60,9 @@ export default class DBModel extends Model {
 
 export function generatePackageJson(name: string, selectedModules: ModuleOption[]): string {
   const devDependencies: Record<string, string> = {
+    qunit: '^2.24.1',
     stonyx: 'latest',
+    tsx: '^4.21.0',
     typescript: '^5.8.3'
   };
 
@@ -80,8 +82,9 @@ export function generatePackageJson(name: string, selectedModules: ModuleOption[
     private: true,
     scripts: {
       build: 'tsc',
+      serve: 'stonyx serve',
       start: 'stonyx serve',
-      test: 'stonyx test'
+      test: "NODE_ENV=test node --import tsx/esm --import ./test/setup.ts node_modules/qunit/bin/qunit.js 'test/**/*-test.ts'"
     },
     devDependencies: sorted
   }, null, 2) + '\n';
@@ -113,8 +116,56 @@ export default class App {
 }
 
 export function generateEnvironmentTs(): string {
-  return `export default {
+  return `import type { StoynxConfig } from 'stonyx';
+
+const config: StoynxConfig = {
+};
+
+export default config;
+`;
 }
+
+export function generateTestEnvironmentTs(): string {
+  return `import type { StoynxConfig } from 'stonyx';
+
+// Test-specific config overrides
+const config: Partial<StoynxConfig> = {
+};
+
+export default config;
+`;
+}
+
+export function generateSetupTs(): string {
+  return `// Test setup: bootstrap Stonyx with the consumer config before qunit runs.
+// Sprint 44 pattern — loaded via \`node --import ./test/setup.ts\`.
+import { pathToFileURL } from 'url';
+
+const cwd = process.cwd();
+
+const { default: Stonyx } = await import('stonyx');
+const { default: config } = await import(pathToFileURL(\`\${cwd}/config/environment.ts\`).href);
+
+new Stonyx(config, cwd);
+
+await Stonyx.ready;
+`;
+}
+
+export function generateZzExitTestTs(): string {
+  return `// Force-exit hook for qunit runs.
+//
+// Stonyx modules may keep listeners/servers open that would otherwise
+// block the process from exiting after tests complete, causing CI to
+// hit timeouts even though all tests passed.
+//
+// Named \`zz-\` so alphabetical test-file order places it last, after
+// all real test files have registered with QUnit.
+import QUnit from 'qunit';
+
+QUnit.on('runEnd', () => {
+  setImmediate(() => process.exit(process.exitCode ?? 0));
+});
 `;
 }
 
@@ -143,8 +194,6 @@ db.json
 *.js
 *.d.ts
 *.js.map
-# Keep test config (JavaScript)
-!test/**/*.js
 `;
 }
 
@@ -182,38 +231,16 @@ function runPnpmInstall(projectDir: string): Promise<void> {
   });
 }
 
-export default async function newCommand({ args }: { args: string[] }): Promise<void> {
-  let appName = args[0];
-
-  if (!appName) {
-    appName = await prompt('Project name:');
-  }
-
-  if (!appName) {
-    console.error('Project name is required.');
-    process.exit(1);
-  }
-
-  const projectDir = path.resolve(process.cwd(), appName);
-
-  if (await fileExists(projectDir)) {
-    console.error(`Directory "${appName}" already exists.`);
-    process.exit(1);
-  }
-
-  console.log(`\nScaffolding new Stonyx project: ${appName}\n`);
-
-  // Prompt for module selection
-  const selectedModules: ModuleOption[] = [];
-
-  for (const mod of MODULE_OPTIONS) {
-    if (await confirm(mod.question)) {
-      selectedModules.push(mod);
-    }
-  }
-
-  console.log('\nCreating project structure...\n');
-
+/**
+ * Write every scaffolded file to disk given a resolved project directory,
+ * app name, and pre-selected module options. Factored out of `newCommand`
+ * so tests can exercise the file-writing path without interactive prompts.
+ */
+export async function scaffoldProject(
+  projectDir: string,
+  appName: string,
+  selectedModules: ModuleOption[]
+): Promise<void> {
   // Create project directory
   await createDirectory(projectDir);
 
@@ -260,8 +287,47 @@ export default async function newCommand({ args }: { args: string[] }): Promise<
   await createDirectory(path.join(projectDir, 'test', 'acceptance'));
   await createFile(path.join(projectDir, 'test', 'acceptance', '.gitkeep'), '');
 
-  // Create test config
-  await createFile(path.join(projectDir, 'test', 'config', 'environment.js'), `export default {\n  // Test-specific config overrides\n}\n`);
+  // Create test config (TS)
+  await createFile(path.join(projectDir, 'test', 'config', 'environment.ts'), generateTestEnvironmentTs());
+
+  // Create Sprint 44 test harness files (setup bootstraps Stonyx, zz-exit-test drains event loop)
+  await createFile(path.join(projectDir, 'test', 'setup.ts'), generateSetupTs());
+  await createFile(path.join(projectDir, 'test', 'zz-exit-test.ts'), generateZzExitTestTs());
+}
+
+export default async function newCommand({ args }: { args: string[] }): Promise<void> {
+  let appName = args[0];
+
+  if (!appName) {
+    appName = await prompt('Project name:');
+  }
+
+  if (!appName) {
+    console.error('Project name is required.');
+    process.exit(1);
+  }
+
+  const projectDir = path.resolve(process.cwd(), appName);
+
+  if (await fileExists(projectDir)) {
+    console.error(`Directory "${appName}" already exists.`);
+    process.exit(1);
+  }
+
+  console.log(`\nScaffolding new Stonyx project: ${appName}\n`);
+
+  // Prompt for module selection
+  const selectedModules: ModuleOption[] = [];
+
+  for (const mod of MODULE_OPTIONS) {
+    if (await confirm(mod.question)) {
+      selectedModules.push(mod);
+    }
+  }
+
+  console.log('\nCreating project structure...\n');
+
+  await scaffoldProject(projectDir, appName, selectedModules);
 
   console.log('Installing dependencies...\n');
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -105,3 +105,4 @@ export default class Stonyx {
 }
 
 export { waitForModule } from './modules.js';
+export type { StoynxConfig } from './modules.js';

--- a/test/unit/cli/new-test.ts
+++ b/test/unit/cli/new-test.ts
@@ -1,11 +1,18 @@
 import QUnit from 'qunit';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
 import newCommand, {
+  scaffoldProject,
   generateAppTs,
   generateTsConfig,
   generatePackageJson,
   generateGitignore,
   generateEnvironmentTs,
   generateEnvironmentExampleTs,
+  generateTestEnvironmentTs,
+  generateSetupTs,
+  generateZzExitTestTs,
   generateDbSchema
 } from '../../../src/cli/new.js';
 
@@ -40,29 +47,62 @@ module('[Unit] CLI New — TypeScript Blueprints', function () {
     assert.ok(config.exclude.includes('test'), 'excludes test');
   });
 
-  test('generatePackageJson includes typescript and build script', function (assert) {
+  test('generatePackageJson includes TS toolchain and Sprint 44 test script', function (assert) {
     const output = generatePackageJson('test-app', []);
     const pkg = JSON.parse(output);
 
     assert.ok(pkg.devDependencies.typescript, 'typescript is a devDependency');
+    assert.ok(pkg.devDependencies.tsx, 'tsx is a devDependency');
+    assert.ok(pkg.devDependencies.qunit, 'qunit is a devDependency');
     assert.strictEqual(pkg.scripts.build, 'tsc', 'build script runs tsc');
+    assert.strictEqual(pkg.scripts.serve, 'stonyx serve', 'serve script runs stonyx serve');
     assert.strictEqual(pkg.scripts.start, 'stonyx serve', 'start script runs stonyx serve');
+    assert.ok(pkg.scripts.test.includes('--import tsx/esm'), 'test script uses tsx/esm loader');
+    assert.ok(pkg.scripts.test.includes('./test/setup.ts'), 'test script imports setup.ts');
+    assert.ok(pkg.scripts.test.includes("'test/**/*-test.ts'"), 'test script targets .ts test files');
+    assert.ok(pkg.scripts.test.includes('NODE_ENV=test'), 'test script sets NODE_ENV=test');
     assert.strictEqual(pkg.type, 'module', 'type is module');
   });
 
-  test('generateGitignore includes compiled output patterns with test exception', function (assert) {
+  test('generateGitignore includes compiled output patterns', function (assert) {
     const output = generateGitignore();
 
     assert.ok(output.includes('*.js'), 'ignores compiled .js files');
     assert.ok(output.includes('*.d.ts'), 'ignores declaration files');
     assert.ok(output.includes('*.js.map'), 'ignores source maps');
-    assert.ok(output.includes('!test/**/*.js'), 'keeps test JS files');
+    assert.notOk(output.includes('!test/**/*.js'), 'no stale .js test exception (TS-native)');
   });
 
-  test('generateEnvironmentTs produces valid TypeScript', function (assert) {
+  test('generateEnvironmentTs produces valid TypeScript with type annotation', function (assert) {
     const output = generateEnvironmentTs();
 
     assert.ok(output.includes('export default'), 'has default export');
+    assert.ok(output.includes('StoynxConfig'), 'references StoynxConfig type');
+    assert.ok(output.includes("from 'stonyx'"), 'imports type from stonyx');
+  });
+
+  test('generateTestEnvironmentTs produces typed partial config override', function (assert) {
+    const output = generateTestEnvironmentTs();
+
+    assert.ok(output.includes('export default'), 'has default export');
+    assert.ok(output.includes('Partial<StoynxConfig>'), 'uses Partial<StoynxConfig>');
+  });
+
+  test('generateSetupTs bootstraps Stonyx and awaits ready', function (assert) {
+    const output = generateSetupTs();
+
+    assert.ok(output.includes("await import('stonyx')"), 'imports stonyx');
+    assert.ok(output.includes('new Stonyx(config, cwd)'), 'constructs Stonyx instance');
+    assert.ok(output.includes('await Stonyx.ready'), 'awaits Stonyx.ready');
+    assert.ok(output.includes('config/environment.ts'), 'loads config/environment.ts');
+  });
+
+  test('generateZzExitTestTs registers runEnd force-exit hook', function (assert) {
+    const output = generateZzExitTestTs();
+
+    assert.ok(output.includes("import QUnit from 'qunit'"), 'imports QUnit');
+    assert.ok(output.includes("QUnit.on('runEnd'"), 'registers runEnd hook');
+    assert.ok(output.includes('process.exit'), 'calls process.exit');
   });
 
   test('generateEnvironmentExampleTs references .ts extension in instructions', function (assert) {
@@ -94,3 +134,99 @@ module('[Unit] CLI New — TypeScript Blueprints', function () {
   });
 
 });
+
+module('[Unit] CLI New — Scaffold Output (temp directory)', function (hooks) {
+  let tempDir: string;
+  let projectDir: string;
+
+  hooks.beforeEach(async function () {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'stonyx-new-test-'));
+    projectDir = path.join(tempDir, 'sample-app');
+    // Scaffold with zero selected modules so the output is the minimal TS-native baseline.
+    await scaffoldProject(projectDir, 'sample-app', []);
+  });
+
+  hooks.afterEach(async function () {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  test('produces no .js files anywhere in the scaffolded tree', async function (assert) {
+    const jsFiles = await collectFiles(projectDir, (name) => name.endsWith('.js'));
+    assert.deepEqual(jsFiles, [], 'no .js files scaffolded into new project');
+  });
+
+  test('scaffolds tsconfig.json with Stonyx-recommended settings (no paths)', async function (assert) {
+    const tsconfigPath = path.join(projectDir, 'tsconfig.json');
+    const raw = await fs.readFile(tsconfigPath, 'utf8');
+    const parsed = JSON.parse(raw);
+
+    assert.strictEqual(parsed.compilerOptions.strict, true, 'strict mode');
+    assert.strictEqual(parsed.compilerOptions.module, 'NodeNext', 'module NodeNext');
+    assert.strictEqual(parsed.compilerOptions.target, 'ES2022', 'target ES2022');
+    assert.notOk(parsed.compilerOptions.paths, 'no paths (per Sprint 45 finding)');
+  });
+
+  test('scaffolds package.json with tsx + typescript + Sprint 44 test script', async function (assert) {
+    const pkgPath = path.join(projectDir, 'package.json');
+    const pkg = JSON.parse(await fs.readFile(pkgPath, 'utf8'));
+
+    assert.ok(pkg.devDependencies.tsx, 'tsx in devDependencies');
+    assert.ok(pkg.devDependencies.typescript, 'typescript in devDependencies');
+    assert.ok(pkg.devDependencies.qunit, 'qunit in devDependencies');
+    assert.ok(pkg.scripts.test.includes('--import tsx/esm'), 'test uses tsx/esm');
+    assert.ok(pkg.scripts.test.includes('./test/setup.ts'), 'test imports setup.ts');
+    assert.strictEqual(pkg.scripts.serve, 'stonyx serve', 'serve script present');
+  });
+
+  test('scaffolds test/setup.ts and test/zz-exit-test.ts (Sprint 44 pattern)', async function (assert) {
+    const setupPath = path.join(projectDir, 'test', 'setup.ts');
+    const zzPath = path.join(projectDir, 'test', 'zz-exit-test.ts');
+
+    const setupContent = await fs.readFile(setupPath, 'utf8');
+    const zzContent = await fs.readFile(zzPath, 'utf8');
+
+    assert.ok(setupContent.includes('await Stonyx.ready'), 'setup.ts awaits Stonyx.ready');
+    assert.ok(zzContent.includes("QUnit.on('runEnd'"), 'zz-exit-test.ts registers runEnd hook');
+  });
+
+  test('scaffolds config/environment.ts with TypeScript type annotations', async function (assert) {
+    const envPath = path.join(projectDir, 'config', 'environment.ts');
+    const envContent = await fs.readFile(envPath, 'utf8');
+
+    assert.ok(envContent.includes('StoynxConfig'), 'references StoynxConfig type');
+    assert.notOk(envContent.match(/^export default \{\}\s*$/m), 'not a bare export default {}');
+  });
+
+  test('scaffolds test/config/environment.ts (not .js)', async function (assert) {
+    const tsExists = await fileExists(path.join(projectDir, 'test', 'config', 'environment.ts'));
+    const jsExists = await fileExists(path.join(projectDir, 'test', 'config', 'environment.js'));
+
+    assert.ok(tsExists, 'test/config/environment.ts exists');
+    assert.notOk(jsExists, 'test/config/environment.js was NOT scaffolded');
+  });
+});
+
+async function collectFiles(dir: string, predicate: (name: string) => boolean): Promise<string[]> {
+  const out: string[] = [];
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules') continue;
+      const nested = await collectFiles(full, predicate);
+      out.push(...nested);
+    } else if (entry.isFile() && predicate(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
Closes #61.

## Summary
- Every `createFile` target in `src/cli/new.ts` that emits consumer source now writes `.ts` — no `.js` leaves the scaffolder.
- Scaffolded `config/environment.ts` carries a `StoynxConfig`-typed default export (re-exported from `stonyx/main` so consumers can import it).
- Scaffolded `package.json` gains `tsx` + `qunit` devDeps and the Sprint 44 test script: `NODE_ENV=test node --import tsx/esm --import ./test/setup.ts node_modules/qunit/bin/qunit.js 'test/**/*-test.ts'`.
- Added `test/setup.ts` (awaits `Stonyx.ready`) and `test/zz-exit-test.ts` (`runEnd` force-exit hook) to every new project — mirrors the stonyx-orm pattern.
- `test/config/environment.js` -> `.ts`; stale `!test/**/*.js` dropped from the scaffolded `.gitignore`.
- `newCommand` refactored to delegate file writes to a new exported `scaffoldProject()` helper, making the scaffolder testable without driving readline prompts.

## Test plan
- [x] `pnpm typecheck` (tsc + tsconfig.test.json) green
- [x] `pnpm test` — all 64 tests pass, including the new `[Unit] CLI New — Scaffold Output (temp directory)` suite that scaffolds into a temp dir and asserts:
  - no `.js` files produced anywhere
  - `tsconfig.json` has strict / NodeNext / ES2022 and NO `paths` (per Sprint 45)
  - `package.json` has `tsx`, `typescript`, `qunit`, and the Sprint 44 test script
  - `test/setup.ts` and `test/zz-exit-test.ts` exist with the expected content
  - `config/environment.ts` references `StoynxConfig` and is not a bare `export default {}`
  - `test/config/environment.ts` exists and `.js` sibling does NOT
- [x] Manually spot-checked scaffolded output end-to-end (minimal project tree contains only `.ts`/`.gitkeep`/`.json` files)

## Docs
`docs/cli.md` `stonyx new` section updated: scaffolded project layout, Sprint 44 test script, and typed `environment.ts` example.

## Notes
Depends on #59 (merged) for TS config loading. A scaffolded project's `stonyx serve` still relies on the CLI's existing `app.js` default — running the scaffolded `app.ts` through `stonyx serve` is out of scope for this issue and would need either a separate CLI change or a `serve` script using `node --import tsx/esm app.ts`; filing as a follow-up if Stone wants it.