### PR TITLE
fix: postinstall detects JS vs TS consumer and ships matching env template (#62)

### DIFF
--- a/config/environment copy.ts
+++ b/config/environment copy.ts
@@ -1,0 +1,16 @@
+import type { StoynxConfig } from 'stonyx';
+
+// project configuration, override-able by listed environment variables
+const {
+  DEBUG,
+  NODE_ENV,
+} = process.env;
+
+const environment = NODE_ENV ?? 'development';
+
+const config: StoynxConfig = {
+  environment,
+  debug: DEBUG ?? environment === 'development',
+};
+
+export default config;

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,7 +23,21 @@ export default {
 
 Stonyx resolves the config by trying `.ts` first, then falling back to `.js`. If both are present `.ts` wins and a warning is logged — the `.js` is almost always a stale compiled artifact or postinstall stub and should be removed.
 
-The `.js` template is auto-generated on `npm install` via the postinstall script if neither extension exists yet.
+### Postinstall template
+
+Stonyx ships two templates in its package — `config/environment copy.ts` and `config/environment copy.js` — and the postinstall script picks the one matching your project type:
+
+- **TypeScript consumers** (`tsconfig.json` present in the project root) receive `config/environment.ts`.
+- **JavaScript consumers** (no `tsconfig.json`) receive `config/environment.js`.
+
+The detection signal is a simple `tsconfig.json` existence check in the consumer root — unambiguous, available at postinstall time, and doesn't require parsing `package.json` or scanning `src/`.
+
+The postinstall is conservative and only seeds when nothing is already in place:
+
+- Skipped if `config/environment.ts` **or** `config/environment.js` already exists — your config is never overwritten.
+- Skipped if you ship `config/environment copy.ts` **or** `config/environment copy.js` as your own template — that's the opt-out signal, and either extension honors it.
+
+To manage your own bootstrap, commit `config/environment copy.ts` (or `.js`) in your repo and Stonyx will leave the postinstall template untouched.
 
 > **Note:** `config/environment.*` is gitignored by default so each environment can have its own settings.
 

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -7,14 +7,31 @@ const { copyFile, createDirectory } = await import('@stonyx/utils/file');
 
 const projectDir = process.env.INIT_CWD;
 const configDir = `${projectDir}/config`;
-const envFile = 'environment.js';
 
-// Skip if the consumer ships its own `config/environment copy.js` template —
-// they manage their own bootstrap (see abofs/stonyx#54).
-if (existsSync(`${configDir}/environment copy.js`)) process.exit(0);
+// Detect consumer project type: presence of `tsconfig.json` in the consumer
+// root signals a TypeScript project (see abofs/stonyx#62). TS consumers can't
+// use the `.js` stub, so we ship both templates and copy the matching one.
+const isTypeScriptConsumer = existsSync(`${projectDir}/tsconfig.json`);
+const extension = isTypeScriptConsumer ? 'ts' : 'js';
+const envFile = `environment.${extension}`;
+const templateFile = `environment copy.${extension}`;
+
+// Skip if the consumer ships its own `config/environment copy.{ts,js}` template —
+// they manage their own bootstrap (see abofs/stonyx#54, extended in abofs/stonyx#62
+// to honor either extension).
+if (
+  existsSync(`${configDir}/environment copy.ts`) ||
+  existsSync(`${configDir}/environment copy.js`)
+) process.exit(0);
+
+// Don't overwrite an existing consumer config (either extension).
+if (
+  existsSync(`${configDir}/environment.ts`) ||
+  existsSync(`${configDir}/environment.js`)
+) process.exit(0);
 
 createDirectory(configDir);
 
-copyFile(`./config/environment copy.js`, `${configDir}/${envFile}`).then(result => {
+copyFile(`./config/${templateFile}`, `${configDir}/${envFile}`).then(result => {
   if (result) console.log(`Stonyx: ${envFile} has been successfully created. Please see README.md for more information.`);
 });

--- a/test/unit/postinstall-test.ts
+++ b/test/unit/postinstall-test.ts
@@ -9,13 +9,17 @@ const { module, test } = QUnit;
 const postinstallScript = resolve(process.cwd(), 'scripts/postinstall.js');
 
 function runPostinstall(initCwd: string) {
-  // Run from the stonyx repo root so the script's relative `./config/environment copy.js`
+  // Run from the stonyx repo root so the script's relative `./config/environment copy.*`
   // source resolves against the real stonyx template.
   execFileSync('node', [postinstallScript], {
     cwd: process.cwd(),
     env: { ...process.env, INIT_CWD: initCwd, npm_config_global: 'false' },
     stdio: 'pipe',
   });
+}
+
+function writeTsconfig(projectDir: string) {
+  writeFileSync(join(projectDir, 'tsconfig.json'), '{}\n');
 }
 
 module('[Unit] Postinstall', function(hooks) {
@@ -29,12 +33,23 @@ module('[Unit] Postinstall', function(hooks) {
     rmSync(projectDir, { recursive: true, force: true });
   });
 
-  test('copies environment.js when consumer has no template of its own', function(assert) {
+  test('copies environment.ts when consumer has tsconfig.json and no template of its own', function(assert) {
+    writeTsconfig(projectDir);
+
     runPostinstall(projectDir);
-    assert.ok(existsSync(join(projectDir, 'config/environment.js')), 'environment.js was created');
+
+    assert.ok(existsSync(join(projectDir, 'config/environment.ts')), 'environment.ts was created');
+    assert.notOk(existsSync(join(projectDir, 'config/environment.js')), 'environment.js was NOT created');
   });
 
-  test('skips copy when consumer ships its own `config/environment copy.js` (abofs/stonyx#54)', function(assert) {
+  test('copies environment.js when consumer has no tsconfig.json and no template of its own', function(assert) {
+    runPostinstall(projectDir);
+
+    assert.ok(existsSync(join(projectDir, 'config/environment.js')), 'environment.js was created');
+    assert.notOk(existsSync(join(projectDir, 'config/environment.ts')), 'environment.ts was NOT created');
+  });
+
+  test('skips copy when consumer ships its own `config/environment copy.js` (abofs/stonyx#54 back-compat)', function(assert) {
     mkdirSync(join(projectDir, 'config'), { recursive: true });
     writeFileSync(join(projectDir, 'config/environment copy.js'), '// consumer template\n');
 
@@ -42,7 +57,60 @@ module('[Unit] Postinstall', function(hooks) {
 
     assert.notOk(
       existsSync(join(projectDir, 'config/environment.js')),
-      'environment.js was not created when consumer ships its own template'
+      'environment.js was not created when consumer ships its own .js template'
+    );
+    assert.notOk(
+      existsSync(join(projectDir, 'config/environment.ts')),
+      'environment.ts was not created when consumer ships its own .js template'
+    );
+  });
+
+  test('skips copy when consumer ships its own `config/environment copy.ts` (abofs/stonyx#62 extended sentinel)', function(assert) {
+    writeTsconfig(projectDir);
+    mkdirSync(join(projectDir, 'config'), { recursive: true });
+    writeFileSync(join(projectDir, 'config/environment copy.ts'), '// consumer template\n');
+
+    runPostinstall(projectDir);
+
+    assert.notOk(
+      existsSync(join(projectDir, 'config/environment.ts')),
+      'environment.ts was not created when consumer ships its own .ts template'
+    );
+    assert.notOk(
+      existsSync(join(projectDir, 'config/environment.js')),
+      'environment.js was not created when consumer ships its own .ts template'
+    );
+  });
+
+  test('skips copy when consumer already has a `config/environment.ts` (no overwrite)', function(assert) {
+    writeTsconfig(projectDir);
+    mkdirSync(join(projectDir, 'config'), { recursive: true });
+    writeFileSync(join(projectDir, 'config/environment.ts'), '// existing consumer config\n');
+
+    runPostinstall(projectDir);
+
+    // Content should be unchanged: no fresh template was copied over top.
+    const { readFileSync } = require('node:fs') as typeof import('node:fs');
+    const contents = readFileSync(join(projectDir, 'config/environment.ts'), 'utf8');
+    assert.strictEqual(contents, '// existing consumer config\n', 'existing environment.ts was not overwritten');
+    assert.notOk(
+      existsSync(join(projectDir, 'config/environment.js')),
+      'environment.js was not created alongside existing .ts'
+    );
+  });
+
+  test('skips copy when consumer already has a `config/environment.js` (no overwrite)', function(assert) {
+    mkdirSync(join(projectDir, 'config'), { recursive: true });
+    writeFileSync(join(projectDir, 'config/environment.js'), '// existing consumer config\n');
+
+    runPostinstall(projectDir);
+
+    const { readFileSync } = require('node:fs') as typeof import('node:fs');
+    const contents = readFileSync(join(projectDir, 'config/environment.js'), 'utf8');
+    assert.strictEqual(contents, '// existing consumer config\n', 'existing environment.js was not overwritten');
+    assert.notOk(
+      existsSync(join(projectDir, 'config/environment.ts')),
+      'environment.ts was not created alongside existing .js'
     );
   });
 });


### PR DESCRIPTION
Closes #62.

## Summary

`scripts/postinstall.js` was hardcoded to copy `config/environment copy.js` → `config/environment.js`, leaving TypeScript consumers with an unusable stub. This PR makes postinstall consumer-type-aware: it detects TS vs JS via `tsconfig.json` in the consumer root, ships both templates in the published tarball, and copies the matching extension.

## Changes

- **New `config/environment copy.ts`** — typed via `StoynxConfig`, same shape as the existing `.js` template. Ships alongside it.
- **`scripts/postinstall.js`** — three coordinated updates:
  - Detect consumer type via `existsSync('${projectDir}/tsconfig.json')`.
  - Extend the stonyx#54 sentinel: skip if EITHER `config/environment copy.ts` OR `.js` is present in the consumer.
  - Guard against overwrite: skip if `config/environment.ts` OR `.js` already exists in the consumer.
- **`test/unit/postinstall-test.ts`** — extended from 2 to 6 cases covering the full detection matrix:
  - TS consumer, no existing env → `environment.ts` created
  - JS consumer, no existing env → `environment.js` created
  - Consumer ships `environment copy.js` → skip (stonyx#54 back-compat)
  - Consumer ships `environment copy.ts` → skip (extended sentinel)
  - Consumer has existing `environment.ts` → skip, no overwrite
  - Consumer has existing `environment.js` → skip, no overwrite
- **`docs/configuration.md`** — new "Postinstall template" subsection documenting the detection signal, per-extension output, and opt-out mechanism.

## Verification

### Tarball

```
$ pnpm pack
Tarball Contents
config/environment copy.js
config/environment copy.ts
LICENSE.md
package.json
README.md
scripts/postinstall.js
```

Both templates are present (confirmed via `tar -tzf` as well). `package.json#files` already includes `config`, so no manifest change was needed.

### Tests

```
1..68
# pass 68
# skip 0
# todo 0
# fail 0
```

All 68 tests pass — including 6 new postinstall cases. Typecheck clean.

## Dependency note

Depends on stonyx#59 (loader `.ts` fallback), which landed as commit `79e42fa` already on dev. The `.ts` template is now loadable at runtime.