### PR TITLE
fix: 'stonyx serve' resolves app.ts then app.js default (#67)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -78,9 +78,11 @@ export default config;
 Bootstraps Stonyx (loads config, initializes modules, runs lifecycle hooks), then imports your application entry point.
 
 ```bash
-stonyx serve                    # Runs app.js by default
-stonyx serve --entry custom.js  # Runs a custom entry file
+stonyx serve                    # Runs app.ts (or app.js) by default
+stonyx serve --entry custom.ts  # Runs a custom entry file
 ```
+
+Both `.ts` and `.js` entry points are supported. When no `--entry` flag is passed, `stonyx serve` looks for `app.ts` first, then falls back to `app.js`. If both exist, `.ts` wins and a warning is logged (the `.js` is likely a stale compiled artifact). When an explicit `--entry <path>` is passed, the provided path is honored verbatim.
 
 The serve command also registers `SIGTERM` and `SIGINT` handlers that run [shutdown hooks](lifecycle.md) before exiting.
 

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -1,5 +1,8 @@
+import { resolve } from 'path';
+import { pathToFileURL } from 'url';
 import { runStartupHooks, runShutdownHooks, type StoynxModule } from '../lifecycle.js';
 import { importConfig } from '../util/import-config.js';
+import { resolveEntryPoint } from '../util/resolve-entry-point.js';
 import type { StoynxConfig } from '../modules.js';
 
 export function createShutdownHandler(modules: StoynxModule[]): () => Promise<void> {
@@ -36,7 +39,8 @@ export function maybeRegisterAppShutdown(
 export default async function serve({ args }: { args: string[] }): Promise<void> {
   const cwd = process.cwd();
   const entryFlag = args.indexOf('--entry');
-  const entryPoint = (entryFlag !== -1 && entryFlag + 1 < args.length) ? args[entryFlag + 1] : 'app.js';
+  const entryArg = (entryFlag !== -1 && entryFlag + 1 < args.length) ? args[entryFlag + 1] : null;
+  const entryPoint = entryArg !== null ? resolve(cwd, entryArg) : resolveEntryPoint(`${cwd}/app`);
 
   const config = await importConfig<StoynxConfig>(`${cwd}/config/environment`);
   const { default: Stonyx } = await import('../main.js');
@@ -52,7 +56,7 @@ export default async function serve({ args }: { args: string[] }): Promise<void>
   process.on('SIGTERM', shutdown);
   process.on('SIGINT', shutdown);
 
-  const entryModule = await import(`${cwd}/${entryPoint}`);
+  const entryModule = await import(pathToFileURL(entryPoint).href);
 
   let appInstance: { shutdown?: () => Promise<void> } | undefined;
   if (entryModule.default) {

--- a/src/util/resolve-entry-point.ts
+++ b/src/util/resolve-entry-point.ts
@@ -1,0 +1,21 @@
+import { existsSync } from 'fs';
+import { resolve } from 'path';
+
+const EXTENSIONS = ['ts', 'js'] as const;
+
+export function resolveEntryPoint(basePath: string): string {
+  const matches = EXTENSIONS.filter(ext => existsSync(resolve(`${basePath}.${ext}`)));
+
+  if (matches.length === 0) {
+    throw new Error(`Entry point not found: ${basePath}.{ts,js}`);
+  }
+
+  if (matches.length > 1) {
+    console.warn(
+      `Warning: both ${basePath}.ts and ${basePath}.js exist. Using .ts — delete the .js to silence this warning (it is likely a stale compiled artifact or postinstall stub).`
+    );
+  }
+
+  const ext = matches[0];
+  return resolve(`${basePath}.${ext}`);
+}

--- a/test/unit/resolve-entry-point-test.ts
+++ b/test/unit/resolve-entry-point-test.ts
@@ -1,0 +1,77 @@
+import QUnit from 'qunit';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveEntryPoint } from '../../src/util/resolve-entry-point.js';
+
+const { module, test } = QUnit;
+
+let dir: string;
+let basePath: string;
+let originalWarn: typeof console.warn;
+let warnCalls: unknown[][];
+
+function setupWarnSpy(): void {
+  originalWarn = console.warn;
+  warnCalls = [];
+  console.warn = (...args: unknown[]) => { warnCalls.push(args); };
+}
+
+function restoreWarn(): void {
+  console.warn = originalWarn;
+}
+
+module('[Unit] resolveEntryPoint', function(hooks) {
+  hooks.beforeEach(function() {
+    dir = mkdtempSync(join(tmpdir(), 'stonyx-resolve-entry-point-'));
+    basePath = join(dir, 'app');
+    setupWarnSpy();
+  });
+
+  hooks.afterEach(function() {
+    restoreWarn();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('resolves to app.ts when only .ts exists', function(assert) {
+    writeFileSync(`${basePath}.ts`, `export default class App {}\n`);
+
+    const resolved = resolveEntryPoint(basePath);
+
+    assert.equal(resolved, `${basePath}.ts`, 'returns absolute .ts path');
+    assert.equal(warnCalls.length, 0, 'no warning logged');
+  });
+
+  test('resolves to app.js when only .js exists', function(assert) {
+    writeFileSync(`${basePath}.js`, `export default class App {}\n`);
+
+    const resolved = resolveEntryPoint(basePath);
+
+    assert.equal(resolved, `${basePath}.js`, 'returns absolute .js path');
+    assert.equal(warnCalls.length, 0, 'no warning logged');
+  });
+
+  test('prefers .ts when both exist and logs a warning', function(assert) {
+    writeFileSync(`${basePath}.ts`, `export default class App {}\n`);
+    writeFileSync(`${basePath}.js`, `export default class App {}\n`);
+
+    const resolved = resolveEntryPoint(basePath);
+
+    assert.equal(resolved, `${basePath}.ts`, '.ts wins');
+    assert.equal(warnCalls.length, 1, 'exactly one warning logged');
+    const [[msg]] = warnCalls as [[string]];
+    assert.ok(msg.includes('.ts'), 'warning mentions .ts');
+    assert.ok(msg.includes('.js'), 'warning mentions .js');
+  });
+
+  test('throws clear error when neither exists', function(assert) {
+    try {
+      resolveEntryPoint(basePath);
+      assert.ok(false, 'should have thrown');
+    } catch (err) {
+      const message = (err as Error).message;
+      assert.ok(message.includes('Entry point not found'), 'error mentions "Entry point not found"');
+      assert.ok(message.includes('ts') && message.includes('js'), 'error references both extensions');
+    }
+  });
+});


### PR DESCRIPTION
Closes #67.

## Summary

`src/cli/serve.ts:39` hardcoded the default entry point to `'app.js'`, so a TS-first project scaffolded via `stonyx new` (Sprint 48 #61) could not `stonyx serve` without an explicit `--entry app.ts` flag.

## Changes

- **New helper** `src/util/resolve-entry-point.ts` — mirrors Sprint 47's `importConfig` pattern. Tries `.ts` then `.js`, prefers `.ts` when both exist (with warning), throws a clear error naming both extensions when neither exists. Returns an absolute resolved path so the caller can hand it to dynamic `import()` via `pathToFileURL`.
- **`src/cli/serve.ts`** — calls `resolveEntryPoint(\`${cwd}/app\`)` when `--entry` is not passed. Explicit `--entry <path>` is honored verbatim (no coercion) and resolved against `cwd`. The import now goes through `pathToFileURL` so absolute paths work correctly on all platforms.
- **`test/unit/resolve-entry-point-test.ts`** — four new tests covering the four branches (ts-only, js-only, both, neither), following the `import-config-test.ts` convention (`mkdtempSync` fixtures, `console.warn` spy).
- **`docs/cli.md`** — `stonyx serve` section updated: both extensions supported, `.ts` preferred, examples use `.ts`.

## Test plan

- [x] `pnpm typecheck` green
- [x] `pnpm test` green — 72 tests pass (4 new + all 68 existing)
- [x] Explicit `--entry` still wins (covered by existing serve tests)