### PR TITLE
fix: resolve standalone module via package.json#name

### DIFF
--- a/docs/developing-modules.md
+++ b/docs/developing-modules.md
@@ -75,12 +75,29 @@ Pass the module name without the `@stonyx/` prefix.
 
 ## Standalone Development
 
-When running a module standalone (project path contains `stonyx-`), Stonyx auto-transforms the config structure. Your module's config is wrapped under its camelCase name:
+When a stonyx module runs its own tests (or is otherwise started as a standalone app), Stonyx auto-wraps the flat test config under the module's camelCase key so module code can read `config.myModule.*` exactly as it would in a consumer app.
+
+**Detection signal:** Stonyx reads the consumer's `package.json#name`:
+
+- `@stonyx/rest-server` (scoped) → wraps under `restServer`
+- `stonyx-rest-server` (unscoped fallback) → wraps under `restServer`
+- Anything else (including missing / malformed `package.json`) → no transform, config is used as-is
 
 ```js
 // If your module is @stonyx/rest-server and config is { port: 3000 }
 // Stonyx transforms it to: { restServer: { port: 3000 } }
 ```
+
+Sibling `config.modules` entries are flattened into the result alongside the wrapped module:
+
+```js
+// Input config:
+//   { port: 3000, modules: { other: { enabled: true } } }
+// Transformed to:
+//   { restServer: { port: 3000, modules: { ... } }, other: { enabled: true } }
+```
+
+**Migration note:** prior versions used a `rootPath.includes('stonyx-')` heuristic, which misfired in worktrees and forks with non-canonical paths. If you maintain a fork, make sure your `package.json#name` still starts with `@stonyx/` or `stonyx-`, or explicitly pass the wrapped config shape from your app's entry point.
 
 ## Custom CLI Commands
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,9 +16,9 @@
 
 import Chronicle from '@stonyx/logs';
 import loadModules from './modules.js';
-import { kebabCaseToCamelCase } from '@stonyx/utils/string';
 import { mergeObject } from '@stonyx/utils/object';
 import { importConfig } from './util/import-config.js';
+import { resolveModuleName } from './util/resolve-module-name.js';
 import type { StoynxModule } from './lifecycle.js';
 import type { StoynxConfig } from './modules.js';
 
@@ -43,11 +43,15 @@ export default class Stonyx {
     if (!config) throw new Error('Stonyx requires full environment configuration on startup');
     if (!rootPath) throw new Error('Stonyx requires root project\'s path on startup');
 
-    // Transform config from stonyx-modules running as a standalone
-    if (rootPath.includes('stonyx-')) {
-      const dirName = rootPath.split('/').pop() ?? '';
-      const moduleName = kebabCaseToCamelCase(dirName.replace('stonyx-', ''));
-      config = { [moduleName]: config, ...((config as Record<string, unknown>).modules as Record<string, unknown> || {}) };
+    // Transform config from stonyx-modules running as a standalone.
+    // Signal is the consumer's `package.json#name` (see resolveModuleName);
+    // this replaces the brittle `rootPath.includes('stonyx-')` heuristic so
+    // non-canonical rootPaths (worktrees, forks, renames) still work.
+    const moduleName = resolveModuleName(rootPath);
+    if (moduleName) {
+      const flatConfig = config as Record<string, unknown>;
+      const siblingModules = (flatConfig.modules as Record<string, unknown>) || {};
+      config = { [moduleName]: config, ...siblingModules };
       delete (config as Record<string, unknown>).modules;
     }
 

--- a/src/util/resolve-module-name.ts
+++ b/src/util/resolve-module-name.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from 'fs';
+import { kebabCaseToCamelCase } from '@stonyx/utils/string';
+
+/**
+ * Resolve a stonyx standalone module's camelCase name from the consumer's
+ * `package.json#name`. Used by the standalone-config transform to wrap a flat
+ * config under the module's key when a stonyx module runs its own tests.
+ *
+ * Recognises:
+ *   - `@stonyx/<kebab>`  → `<camel>`
+ *   - `stonyx-<kebab>`   → `<camel>` (unscoped fallback)
+ *   - Anything else      → `null` (caller should skip the transform)
+ *
+ * Missing or malformed `package.json` returns `null` silently — matches the
+ * fail-safe semantics of the previous `rootPath.includes('stonyx-')` heuristic.
+ */
+export function resolveModuleName(rootPath: string): string | null {
+  let pkg: { name?: unknown };
+
+  try {
+    const raw = readFileSync(`${rootPath}/package.json`, 'utf8');
+    pkg = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+
+  const name = typeof pkg.name === 'string' ? pkg.name : '';
+
+  if (name.startsWith('@stonyx/')) {
+    return kebabCaseToCamelCase(name.slice('@stonyx/'.length));
+  }
+
+  if (name.startsWith('stonyx-')) {
+    return kebabCaseToCamelCase(name.slice('stonyx-'.length));
+  }
+
+  return null;
+}

--- a/test/unit/standalone-transform-test.ts
+++ b/test/unit/standalone-transform-test.ts
@@ -1,0 +1,165 @@
+import QUnit from 'qunit';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveModuleName } from '../../src/util/resolve-module-name.js';
+
+const { module, test } = QUnit;
+
+let dir: string;
+
+/**
+ * Apply the standalone-config transform exactly as `Stonyx.start` does:
+ * if `resolveModuleName` returns a name, wrap the flat config under it and
+ * merge any sibling `config.modules`. Returns the (possibly-transformed)
+ * config so tests can assert on shape without spinning up a Stonyx instance.
+ */
+function applyStandaloneTransform(
+  rawConfig: Record<string, unknown>,
+  rootPath: string
+): Record<string, unknown> {
+  const moduleName = resolveModuleName(rootPath);
+  if (!moduleName) return rawConfig;
+
+  const siblingModules = (rawConfig.modules as Record<string, unknown>) || {};
+  const wrapped: Record<string, unknown> = { [moduleName]: rawConfig, ...siblingModules };
+  delete wrapped.modules;
+  return wrapped;
+}
+
+module('[Unit] standalone-transform', function(hooks) {
+  hooks.beforeEach(function() {
+    dir = mkdtempSync(join(tmpdir(), 'stonyx-standalone-transform-'));
+  });
+
+  hooks.afterEach(function() {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('scoped @stonyx/rest-server name wraps config under restServer at arbitrary rootPath', function(assert) {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: '@stonyx/rest-server' }));
+
+    const result = applyStandaloneTransform({ port: 3000 }, dir);
+
+    assert.deepEqual(result, { restServer: { port: 3000 } }, 'wrapped under restServer');
+  });
+
+  test('unscoped stonyx-rest-server name wraps config under restServer at arbitrary rootPath', function(assert) {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'stonyx-rest-server' }));
+
+    const result = applyStandaloneTransform({ port: 3000 }, dir);
+
+    assert.deepEqual(result, { restServer: { port: 3000 } }, 'wrapped under restServer');
+  });
+
+  test('non-stonyx name (my-app) leaves config flat, no transform', function(assert) {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'my-app' }));
+
+    const input = { port: 3000, someFlag: true };
+    const result = applyStandaloneTransform(input, dir);
+
+    assert.strictEqual(result, input, 'returns the original config reference');
+    assert.deepEqual(result, { port: 3000, someFlag: true }, 'config shape unchanged');
+  });
+
+  test('missing package.json leaves config flat, does not throw', function(assert) {
+    const input = { port: 3000 };
+
+    let result: Record<string, unknown> | undefined;
+    try {
+      result = applyStandaloneTransform(input, dir);
+    } catch (err) {
+      assert.ok(false, `should not throw, got: ${(err as Error).message}`);
+      return;
+    }
+
+    assert.strictEqual(result, input, 'returns the original config reference');
+    assert.deepEqual(result, { port: 3000 }, 'config shape unchanged');
+  });
+
+  test('malformed package.json (invalid JSON) leaves config flat, does not throw', function(assert) {
+    writeFileSync(join(dir, 'package.json'), '{ this is not valid JSON !!! ');
+
+    const input = { port: 3000 };
+
+    let result: Record<string, unknown> | undefined;
+    try {
+      result = applyStandaloneTransform(input, dir);
+    } catch (err) {
+      assert.ok(false, `should not throw, got: ${(err as Error).message}`);
+      return;
+    }
+
+    assert.strictEqual(result, input, 'returns the original config reference');
+    assert.deepEqual(result, { port: 3000 }, 'config shape unchanged');
+  });
+
+  test('sibling config.modules merges into wrapped result as siblings of the wrapped key', function(assert) {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: '@stonyx/rest-server' }));
+
+    const input: Record<string, unknown> = {
+      port: 3000,
+      modules: {
+        other: { enabled: true, endpoint: '/foo' },
+      },
+    };
+
+    const result = applyStandaloneTransform(input, dir);
+
+    assert.ok(result.restServer, 'has restServer key');
+    assert.deepEqual(
+      (result.restServer as Record<string, unknown>).port,
+      3000,
+      'flat config values live under restServer'
+    );
+    assert.deepEqual(
+      result.other,
+      { enabled: true, endpoint: '/foo' },
+      'sibling modules merged at the top level'
+    );
+  });
+});
+
+module('[Unit] resolveModuleName', function(hooks) {
+  hooks.beforeEach(function() {
+    dir = mkdtempSync(join(tmpdir(), 'stonyx-resolve-module-name-'));
+  });
+
+  hooks.afterEach(function() {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('returns camelCase for scoped @stonyx/<kebab>', function(assert) {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: '@stonyx/rest-server' }));
+
+    assert.equal(resolveModuleName(dir), 'restServer');
+  });
+
+  test('returns camelCase for unscoped stonyx-<kebab>', function(assert) {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'stonyx-rest-server' }));
+
+    assert.equal(resolveModuleName(dir), 'restServer');
+  });
+
+  test('returns null for non-stonyx name', function(assert) {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ name: 'my-app' }));
+
+    assert.strictEqual(resolveModuleName(dir), null);
+  });
+
+  test('returns null when package.json is missing', function(assert) {
+    assert.strictEqual(resolveModuleName(dir), null);
+  });
+
+  test('returns null when package.json is malformed', function(assert) {
+    writeFileSync(join(dir, 'package.json'), '{ not valid JSON');
+
+    assert.strictEqual(resolveModuleName(dir), null);
+  });
+
+  test('returns null when name field is missing', function(assert) {
+    writeFileSync(join(dir, 'package.json'), JSON.stringify({ version: '1.0.0' }));
+
+    assert.strictEqual(resolveModuleName(dir), null);
+  });
+});


### PR DESCRIPTION
## Summary

- Replace the fragile `rootPath.includes('stonyx-')` heuristic in `Stonyx.start()` with a `package.json#name`-based signal (scoped `@stonyx/<kebab>` or unscoped `stonyx-<kebab>`).
- Extract the transform to `src/util/resolve-module-name.ts` so it can be unit-tested in isolation, following the Sprint 47/49 `importConfig` / `resolveEntryPoint` pattern.
- Missing / malformed `package.json` is silently treated as non-stonyx (matches the prior `.includes('stonyx-')` fail-safe).
- Sibling `config.modules` merge behaviour preserved byte-for-byte.
- `docs/developing-modules.md` updated to document the new detection signal and the fork-migration note.

Closes #71

## Behaviour matrix

| consumer `name`              | rootPath                                          | result                       |
| ---------------------------- | ------------------------------------------------- | ---------------------------- |
| `@stonyx/rest-server`        | any (worktree, fork, primary)                     | wraps under `restServer`     |
| `stonyx-rest-server`         | any                                               | wraps under `restServer`     |
| `my-app`                     | any                                               | no transform (flat config)   |
| *(missing `package.json`)*   | any                                               | no transform, no throw       |
| *(malformed `package.json`)* | any                                               | no transform, no throw       |

## Test plan

- [x] `pnpm test` (72 → 84 passing; 12 new cases covering the helper + the transform)
- [x] `pnpm typecheck`
- [x] Existing standalone-module test suites still green
- [ ] CI green on `dev`
- [ ] After merge + beta publish, verify `@stonyx/rest-server` / `@stonyx/discord` worktree test-runs work end-to-end (likely also fixes the `log.discord` latent bug noted in the refinement — the wrapped key now matches the camelCase name the discord module reads via `log.discord`)

Generated with Claude Code