### PR TITLE
fix(import-config): enforce .js-only config resolution (#73)

### DIFF
--- a/docs/conventions/framework-modules.md
+++ b/docs/conventions/framework-modules.md
@@ -2,6 +2,16 @@
 
 When to use which `@stonyx/*` module. Always check these before reaching for Node built-ins or npm packages.
 
+## Module `config/environment.js` is always JavaScript
+
+Every `@stonyx/*` module that exposes default configuration does so through `config/environment.js`. This file is a **consumer contract**, not implementation code.
+
+- Consuming projects are pure JavaScript.
+- Node's type-strip loader refuses to process `.ts` files inside `node_modules`, so shipping a `.ts` config crashes every consumer at load time.
+- Stonyx's module loader (`src/util/import-config.ts`) therefore resolves `config/environment.js` only. If the `.js` file is missing, the loader throws `Config not found: …/config/environment.js` — there is no `.ts` fallback.
+
+TS-migration PRs in `@stonyx/*` modules **must** skip `config/environment.*` — leave it as `.js`. If you find a module shipping `config/environment.ts`, that is a P0 consumer crash; rename it back to `.js` immediately.
+
 ## `stonyx/log`
 
 All logging goes through `stonyx/log` (see universal rules in [conventions index](./index.md)).

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -115,7 +115,7 @@ export default async function loadModules(
       initializeModule(moduleName, moduleClass, modules, initPromises);
     } catch (error) {
       console.error(error);
-      throw new Error(`Stonyx modules with async loading must have a config/environment.{ts,js} file with default configurations. Module "${moduleName}" failed to load.`);
+      throw new Error(`Stonyx modules with async loading must have a config/environment.js file with default configurations. Module "${moduleName}" failed to load.`);
     }
   }
 

--- a/src/util/import-config.ts
+++ b/src/util/import-config.ts
@@ -1,22 +1,11 @@
 import { existsSync } from 'fs';
 import { pathToFileURL } from 'url';
 
-const EXTENSIONS = ['ts', 'js'] as const;
-
 export async function importConfig<T = unknown>(basePath: string): Promise<T> {
-  const matches = EXTENSIONS.filter(ext => existsSync(`${basePath}.${ext}`));
-
-  if (matches.length === 0) {
-    throw new Error(`Config not found: ${basePath}.{ts,js}`);
+  const path = `${basePath}.js`;
+  if (!existsSync(path)) {
+    throw new Error(`Config not found: ${path}`);
   }
-
-  if (matches.length > 1) {
-    console.warn(
-      `Warning: both ${basePath}.ts and ${basePath}.js exist. Using .ts — delete the .js to silence this warning (it is likely a stale compiled artifact or postinstall stub).`
-    );
-  }
-
-  const ext = matches[0];
-  const mod = await import(pathToFileURL(`${basePath}.${ext}`).href);
+  const mod = await import(pathToFileURL(path).href);
   return mod.default as T;
 }

--- a/test/unit/import-config-test.ts
+++ b/test/unit/import-config-test.ts
@@ -8,40 +8,16 @@ const { module, test } = QUnit;
 
 let dir: string;
 let basePath: string;
-let originalWarn: typeof console.warn;
-let warnCalls: unknown[][];
-
-function setupWarnSpy(): void {
-  originalWarn = console.warn;
-  warnCalls = [];
-  console.warn = (...args: unknown[]) => { warnCalls.push(args); };
-}
-
-function restoreWarn(): void {
-  console.warn = originalWarn;
-}
 
 module('[Unit] importConfig', function(hooks) {
   hooks.beforeEach(function() {
     // Unique subdir per test so module import cache can't collide across tests
     dir = mkdtempSync(join(tmpdir(), 'stonyx-import-config-'));
     basePath = join(dir, 'environment');
-    setupWarnSpy();
   });
 
   hooks.afterEach(function() {
-    restoreWarn();
     rmSync(dir, { recursive: true, force: true });
-  });
-
-  test('returns default export when only .ts exists', async function(assert) {
-    writeFileSync(`${basePath}.ts`, `export default { source: 'ts', port: 3000 };\n`);
-
-    const config = await importConfig<{ source: string; port: number }>(basePath);
-
-    assert.equal(config.source, 'ts');
-    assert.equal(config.port, 3000);
-    assert.equal(warnCalls.length, 0, 'no warning logged');
   });
 
   test('returns default export when only .js exists', async function(assert) {
@@ -51,35 +27,35 @@ module('[Unit] importConfig', function(hooks) {
 
     assert.equal(config.source, 'js');
     assert.equal(config.port, 4000);
-    assert.equal(warnCalls.length, 0, 'no warning logged');
   });
 
-  test('prefers .ts when both exist and logs a warning', async function(assert) {
+  test('throws "Config not found: *.js" when only .ts exists', async function(assert) {
     writeFileSync(`${basePath}.ts`, `export default { source: 'ts' };\n`);
-    writeFileSync(`${basePath}.js`, `export default { source: 'js' };\n`);
 
-    const config = await importConfig<{ source: string }>(basePath);
-
-    assert.equal(config.source, 'ts', '.ts wins');
-    assert.equal(warnCalls.length, 1, 'exactly one warning logged');
-    const [[msg]] = warnCalls as [[string]];
-    assert.ok(msg.includes('.ts'), 'warning mentions .ts');
-    assert.ok(msg.includes('.js'), 'warning mentions .js');
-  });
-
-  test('throws clear error when neither exists', async function(assert) {
     try {
       await importConfig(basePath);
       assert.ok(false, 'should have thrown');
     } catch (err) {
       const message = (err as Error).message;
-      assert.ok(message.includes('Config not found'), 'error mentions "Config not found"');
-      assert.ok(message.includes('ts') && message.includes('js'), 'error references both extensions');
+      assert.ok(message.startsWith('Config not found'), 'error starts with "Config not found"');
+      assert.ok(message.endsWith('.js'), 'error references .js (not .ts)');
+      assert.notOk(message.includes('.ts'), '.ts is not a supported extension');
+    }
+  });
+
+  test('throws "Config not found: *.js" when neither exists', async function(assert) {
+    try {
+      await importConfig(basePath);
+      assert.ok(false, 'should have thrown');
+    } catch (err) {
+      const message = (err as Error).message;
+      assert.ok(message.startsWith('Config not found'), 'error starts with "Config not found"');
+      assert.ok(message.endsWith('.js'), 'error references .js');
     }
   });
 
   test('propagates non-"not found" import errors (syntax error)', async function(assert) {
-    writeFileSync(`${basePath}.ts`, `export default { this is invalid syntax !!! };\n`);
+    writeFileSync(`${basePath}.js`, `export default { this is invalid syntax !!! };\n`);
 
     try {
       await importConfig(basePath);


### PR DESCRIPTION
## Summary

Simplifies `src/util/import-config.ts` to resolve `config/environment.js` **only**. If the `.js` file is missing, the loader throws a clear `Config not found: *.js` error — there is no `.ts` fallback and no "both exist" warning.

This codifies the consumer contract at the loader level. Node's type-strip loader refuses `.ts` files inside `node_modules`, so any `@stonyx/*` module that ever reintroduces a `.ts` config now fails with a loud, early loader error instead of crashing every consumer app at runtime.

Hardens against regression of the live P0 fixed in [stonyx-orm#118](https://github.com/abofs/stonyx-orm/pull/118) — `@stonyx/orm@0.3.1` shipped `config/environment.ts` and crashed all consumers because Node refused to type-strip inside `node_modules`.

Refs: #73

## Changes

- `src/util/import-config.ts` — trimmed to `.js`-only resolution; throws `Config not found: <path>.js` when missing.
- `src/modules.ts` — error message updated from `config/environment.{ts,js}` to `config/environment.js`.
- `test/unit/import-config-test.ts` — tests now assert the new contract:
  - only `.js` exists resolves and returns `default`
  - only `.ts` exists (no `.js`) throws `Config not found: *.js`
  - neither exists throws `Config not found: *.js`
  - syntax error in `.js` propagates a non-"not found" error
- `docs/conventions/framework-modules.md` — new section **"Module `config/environment.js` is always JavaScript"** codifying that TS-migration PRs in `@stonyx/*` modules must skip `config/environment.*`.

Other callers of `importConfig` (`src/cli.ts`, `src/cli/serve.ts`, `src/cli/test-setup.ts`, `src/main.ts`) already resolve `.js` consumer/first-party paths — no changes needed.

## Test plan

- [x] `pnpm install && pnpm test` — all 83 tests pass, including the 4 new/updated importConfig cases
- [ ] CI green on `dev`