### PR TITLE
docs: drop "100% JavaScript" language-promotion bullet from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 **Stonyx** is a lightweight, modular framework for building modern Node.js applications. It provides a plug-and-play architecture, centralized color-coded logging, and seamless async module integration.
 
-- 100% JavaScript (ES Modules)
 - Drop-in module system — no boilerplate
 - Automatic async module loading and initialization
 - Built-in CLI for scaffolding, bootstrapping, and testing


### PR DESCRIPTION
## Summary

Drops the `- 100% JavaScript (ES Modules)` bullet from `README.md`. Stonyx migrated to TypeScript, but the intent here is **not** a label swap — the framework stops promoting source language as a headline feature. Module system is already implied by `package.json#type: "module"` and the CLI docs.

Refs abofs/stonyx#77 (umbrella — do not auto-close; sibling PRs in stonyx-orm + stonyx-utils land the rest).

## Validation (Tier-1, ephemeral)

- `grep -n '100% JavaScript' README.md` → zero matches ✅
- Broader sanity grep across `docs/` surfaced one residual in `docs/conventions/framework-modules.md` that the CTO adjudicated as **out-of-scope** (architectural constraint statement on consumer JS requirement, not language promotion). Stays untouched.

## Test plan

- [x] README renders on GitHub without the dropped bullet
- [x] No behavioral code changes (doc-only)